### PR TITLE
Multiple Edits - Add support for multiple config files | Add support for weapons release force direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,13 @@ optional arguments:
 - `--teleplot` is the destination IP:port address for teleplot.fr telemetry plotting service (default is "127.0.0.1:47269"). This service allows you to plot telemetry data over time.
 - `-p` or `--plot` is used to specify telemetry item names to send to teleplot, separated by spaces
 - `-D` or `--device` is used to specify the Rhino device USB VID:PID (default is "ffff:2055")
+- `-c` or `--configfile` is used to specify a config file to load (default is "config.ini")
 
 2. Telemetry effects mainly uses Constant Force and Periodic effects. On the Rhino it was tested with **50% Periodic** effect slider, and **100% CF** effect slider setting.
 3. Run DCS World
 4. Enjoy enhanced FFB effects while flying various aircrafts in DCS World!
+
+Note: If you have multiple VPForce FFB Enabled devices (Rhino, DIY Pedals, etc) it is possible to run multiple instances of TelemFFB if you specify the VID:PID when launching.  You can use the config file option to tune the effects for each peripheral in separate config files
 
 ## Contributing
 If you're interested in contributing to the project, feel free to submit pull requests or open issues on the Github page. Your feedback and suggestions are always welcome!

--- a/aircrafts.py
+++ b/aircrafts.py
@@ -20,6 +20,8 @@ from typing import List, Dict
 from ffb_rhino import HapticEffect
 import utils
 import logging
+import random
+
 
 #unit conversions (to m/s)
 knots = 0.514444
@@ -48,6 +50,7 @@ class Aircraft(object):
     gun_vibration_intensity : float = 0.12
     cm_vibration_intensity : float = 0.12
     weapon_release_intensity : float = 0.12
+    weapon_effect_direction: str = 45
 
     ####
     def __init__(self, name : str, **kwargs):
@@ -130,14 +133,36 @@ class Aircraft(object):
     def _update_cm_weapons(self, telem_data):
         if self.has_changed("PayloadInfo"):
             effects["cm"].stop()
-            effects["cm"].periodic(10, self.weapon_release_intensity, 45, duration=80).start()
+            # If effect direction is set to random (-1) in ini file, randomize direction - else, use configured direction (default=45)
+            if self.weapon_effect_direction == -1:
+                #Init random number for effect direction
+                random_weapon_release_direction = random.randint(0, 359)
+                logging.info(f"Payload Effect Direction is randomized: {random_weapon_release_direction} deg")
+                effects["cm"].periodic(10, self.weapon_release_intensity, random_weapon_release_direction, duration=80).start()
+            else:
+                effects["cm"].periodic(10, self.weapon_release_intensity, self.weapon_effect_direction, duration=80).start()
 
         if self.has_changed("Gun") or self.has_changed("CannonShells"):
             effects["cm"].stop()
-            effects["cm"].periodic(10, self.gun_vibration_intensity, 45, duration=50).start()
+            # If effect direction is set to random (-1) in ini file, randomize direction - else, use configured direction (default=45)
+            if self.weapon_effect_direction == -1:
+                #Init random number for effect direction
+                random_weapon_release_direction = random.randint(0, 359)
+                logging.info(f"Gun Effect Direction is randomized: {random_weapon_release_direction} deg")
+                effects["cm"].periodic(10, self.gun_vibration_intensity, random_weapon_release_direction, duration=80).start()
+            else:
+                effects["cm"].periodic(10, self.gun_vibration_intensity, self.weapon_effect_direction, duration=80).start()
+        
         if self.has_changed("Flares") or self.has_changed("Chaff"):
             effects["cm"].stop()
-            effects["cm"].periodic(5, self.cm_vibration_intensity, 45, duration=30).start()
+            # If effect direction is set to random (-1) in ini file, randomize direction - else, use configured direction (default=45)
+            if self.weapon_effect_direction == -1:
+                #Init random number for effect direction
+                random_weapon_release_direction = random.randint(0, 359)
+                logging.info(f"CM Effect Direction is randomized: {random_weapon_release_direction} deg")
+                effects["cm"].periodic(10, self.cm_vibration_intensity, random_weapon_release_direction, duration=80).start()
+            else:
+                effects["cm"].periodic(10, self.cm_vibration_intensity, self.weapon_effect_direction, duration=80).start()
 
     def on_telemetry(self, telem_data : dict):
         """when telemetry frame is received, aircraft class receives data in dict format

--- a/aircrafts.py
+++ b/aircrafts.py
@@ -50,7 +50,7 @@ class Aircraft(object):
     gun_vibration_intensity : float = 0.12
     cm_vibration_intensity : float = 0.12
     weapon_release_intensity : float = 0.12
-    weapon_effect_direction: str = 45
+    weapon_effect_direction: int = 45
 
     ####
     def __init__(self, name : str, **kwargs):

--- a/config.ini
+++ b/config.ini
@@ -7,6 +7,8 @@ runway_rumble_intensity = 1.0 # peak runway intensity, 0 to disable
 gun_vibration_intensity = 0.12
 cm_vibration_intensity = 0.12
 weapon_release_intensity = 0.12
+# set weapon_effect_direction to -1 for random wandering of direction
+# weapon_effect_direction = 45
 
 [TF-51D]
 type=PropellerAircraft

--- a/config.ini
+++ b/config.ini
@@ -8,13 +8,29 @@ gun_vibration_intensity = 0.12
 cm_vibration_intensity = 0.12
 weapon_release_intensity = 0.12
 # set weapon_effect_direction to -1 for random wandering of direction
-# weapon_effect_direction = 45
+weapon_effect_direction = 45
 
 [TF-51D]
 type=PropellerAircraft
 buffeting_intensity = 0.0 # implemented by DCS
 runway_rumble_intensity = 1.0
 engine_rumble = True # rumble based on RPM
+
+[P-47D-30]
+type=PropellerAircraft
+engine_rumble = False # rumble based on RPM
+
+[SpitfireLFMkIX]
+type=PropellerAircraft
+engine_rumble = False # rumble based on RPM
+
+[FW-190A8]
+type=PropellerAircraft
+engine_rumble = False # rumble based on RPM
+
+[FW-190D9]
+type=PropellerAircraft
+engine_rumble = False # rumble based on RPM
 
 [Ka-50]
 type=Helicopter
@@ -47,6 +63,10 @@ type=Helicopter
 [FA-18C_hornet]
 type=JetAircraft
 runway_rumble_intensity=5.0
+
+[F-15ESE]
+type=JetAircraft
+runway_rumble_intensity=3.0
 
 [AH-64D_BLK_II]
 type=Helicopter

--- a/export/TelemFFB.lua
+++ b/export/TelemFFB.lua
@@ -354,7 +354,7 @@ local f_telemFFB = {
             -- FW-190D9 sends to SimShaker
             stringToSend =
               string.format(
-              "T=%.3f;N=%s;SelfData=%s;EngineRPM=%.2f;VlctVectors=%s;altAgl=%.2f;PanShake=%s;Gun=%s;ACCs=%s;Grn-Red-Lights=0;MP-MW=%.2f~%.2f;Wind=%s;altASL=%.2f;14_AoA=%.1f;PayloadInfo=%s;16d=0;17d=0;18d=0;19d=0;20d=0;TAS=%.2f",
+              "T=%.3f;N=%s;SelfData=%s;EngRPM=%.2f;VlctVectors=%s;altAgl=%.2f;PanShake=%s;Gun=%s;ACCs=%s;Grn-Red-Lights=0;MP-MW=%.2f~%.2f;Wind=%s;altASL=%.2f;14_AoA=%.1f;PayloadInfo=%s;16d=0;17d=0;18d=0;19d=0;20d=0;TAS=%.2f",
               t,
               obj.Name,
               myselfData,
@@ -390,7 +390,7 @@ local f_telemFFB = {
             -- Bf-109K-4 sends to SimShaker
             stringToSend =
               string.format(
-              "T=%.3f;N=%s;SelfData=%s;EngineRPM=%.2f;VlctVectors=%s;altAgl=%.2f;PanShake=%s;Gun=%i;9_ACCs=%s;10_Grn-Red-Lights=0;11_MP-MW=%.2f~%.2f;Wind=%s;altASL=%.2f;14_AoA=%.1f;PayloadInfo=%s;16d=0;17d=0;18d=0;19d=0;20d=0;TAS=%.2f",
+              "T=%.3f;N=%s;SelfData=%s;EngRPM=%.2f;VlctVectors=%s;altAgl=%.2f;PanShake=%s;Gun=%i;9_ACCs=%s;10_Grn-Red-Lights=0;11_MP-MW=%.2f~%.2f;Wind=%s;altASL=%.2f;14_AoA=%.1f;PayloadInfo=%s;16d=0;17d=0;18d=0;19d=0;20d=0;TAS=%.2f",
               t,
               obj.Name,
               myselfData,
@@ -473,7 +473,7 @@ local f_telemFFB = {
             -- F-86F sends to SimShaker
             stringToSend =
               string.format(
-              "T=%.3f;N=%s;SelfData=%s;EngineRPM=%.0f;VlctVectors=%s;altAgl=%.2f;PanShake=%s;Gun=%s;ACCs=%s;Gr-RedLight=0;11d=0;Wind=%s;altASL=%.2f;AoA=%.2f;PayloadInfo=%s;16d=0;17d=0;18d=0;19d=0;20d=0;TAS=%.2f",
+              "T=%.3f;N=%s;SelfData=%s;EngRPM=%.0f;VlctVectors=%s;altAgl=%.2f;PanShake=%s;Gun=%s;ACCs=%s;Gr-RedLight=0;11d=0;Wind=%s;altASL=%.2f;AoA=%.2f;PayloadInfo=%s;16d=0;17d=0;18d=0;19d=0;20d=0;TAS=%.2f",
               t,
               obj.Name,
               myselfData,
@@ -571,7 +571,7 @@ local f_telemFFB = {
             -- MiG-15Bis sends to SimShaker
             stringToSend =
               string.format(
-              "T=%.3f;N=%s;SelfData=%s;EngineRPM=%i;VlctVectors=%s;altAgl=%.2f;PanShake=0;Gun=%s;ACCs=%s;Gr-RedLight=%s;d=0;Wind=%s;altASL=%.2f;AoA=%.2f;Payload=%s;Flaps=0;17d=0;18_Canopy=%.1f;19d=0;20d=0;TAS=%.2f",
+              "T=%.3f;N=%s;SelfData=%s;EngRPM=%i;VlctVectors=%s;altAgl=%.2f;PanShake=0;Gun=%s;ACCs=%s;Gr-RedLight=%s;d=0;Wind=%s;altASL=%.2f;AoA=%.2f;Payload=%s;Flaps=0;17d=0;18_Canopy=%.1f;19d=0;20d=0;TAS=%.2f",
               t,
               obj.Name,
               myselfData,

--- a/export/TelemFFB.lua
+++ b/export/TelemFFB.lua
@@ -372,6 +372,7 @@ local f_telemFFB = {
               PayloadInfo,
               tas
             )
+			
           elseif obj.Name == "Bf-109K-4" then
             -------------------------------------------------------------------------------------------------------------------------------------------------------
             local Manifold_Pressure = MainPanel:get_argument_value(32)
@@ -409,7 +410,7 @@ local f_telemFFB = {
             )
           elseif obj.Name == "SpitfireLFMkIX" or obj.Name == "SpitfireLFMkIXCW" then
             -------------------------------------------------------------------------------------------------------------------------------------------------------
-            local Engine_RPM = MainPanel:get_argument_value(37)
+            local Engine_RPM = MainPanel:get_argument_value(37) * 10000
             local PanelShake =
               string.format(
               "%.2f~%.2f~%.2f",
@@ -417,7 +418,37 @@ local f_telemFFB = {
               MainPanel:get_argument_value(143),
               MainPanel:get_argument_value(142)
             )
-            -- SPITFIRE sends to SimShaker
+            -- SPITFIRE sends to TelemFFB
+            stringToSend =
+              string.format(
+              "T=%.3f;N=%s;SelfData=%s;EngRPM=%.0f;VlctVectors=%s;altAgl=%.2f;PanShake=%s;CannonShells=%.0f;ACCs=%s;d10=0;d11=0~0;Wind=%s;altASL=%.2f;AoA=%.1f;PayloadInfo=%s;16d=0;17d=0;18d=0;19d=0;20d=0;TAS=%.2f",
+              t,
+              obj.Name,
+              myselfData,
+              Engine_RPM,
+              velocityVectors,
+              altAgl,
+              PanelShake,
+              CannonShells,
+              AccelerationUnits,
+              windVelocityVectors,
+              altAsl,
+              aoa,
+              PayloadInfo,
+              tas
+            )
+			elseif obj.Name == "P-47D-30" then
+            -------------------------------------------------------------------------------------------------------------------------------------------------------
+            local Engine_RPM = MainPanel:get_argument_value(23) * 4500
+
+            local PanelShake =
+              string.format(
+              "%.2f~%.2f~%.2f",
+              MainPanel:get_argument_value(180),
+              MainPanel:get_argument_value(181),
+              MainPanel:get_argument_value(189)
+            )
+            -- P47 sends to TelemFFB
             stringToSend =
               string.format(
               "T=%.3f;N=%s;SelfData=%s;EngRPM=%.0f;VlctVectors=%s;altAgl=%.2f;PanShake=%s;CannonShells=%.0f;ACCs=%s;d10=0;d11=0~0;Wind=%s;altASL=%.2f;AoA=%.1f;PayloadInfo=%s;16d=0;17d=0;18d=0;19d=0;20d=0;TAS=%.2f",

--- a/export/TelemFFB.lua
+++ b/export/TelemFFB.lua
@@ -34,15 +34,11 @@ local f_telemFFB = {
           local AccelerationUnits = "0.00~0.00~0.00"
           local IAS = LoGetIndicatedAirSpeed() -- m/s
           local M_number = LoGetMachNumber()
-
           local LeftGear = LoGetAircraftDrawArgumentValue(6)
           local NoseGear = LoGetAircraftDrawArgumentValue(1)
           local RightGear = LoGetAircraftDrawArgumentValue(4)
-
           local WoW = string.format("%.2f~%.2f~%.2f", LeftGear, NoseGear, RightGear)
-
           local mech = JSON:encode(LoGetMechInfo()):gsub("\n", "")
-
 
           if acceleration then
             AccelerationUnits = string.format("%.2f~%.2f~%.2f", acceleration.x, acceleration.y, acceleration.z)
@@ -813,9 +809,9 @@ local f_telemFFB = {
             -------------------------------------------------------------------------------------------------------------------------------------------------------
             -- let's try some dcs bios magic
             local li = parse_indication(5)
-      if RPM == nil then 
-        RPM = "0~0"
-      end
+			if RPM == nil then 
+				RPM = "0~0"
+			end
       
 			if li then
               local LEngine_RPM = check(li.txt_RPM_L)
@@ -825,32 +821,32 @@ local f_telemFFB = {
               end
 			end
 			
-            -- FA-18C sends to SimShaker
-            stringToSend=string.format("T=%.3f;N=%s;SelfData=%s;Engine_RPM=%s;VlctVectors=%s;altAgl=%.2f;PanShake=%s;Gun=%s;ACCs=%s;d10=0;IAS=%.2f;Wind=%s;altASL=%.2f;AoA=%.2f;PayloadInfo=%s;16d=0;M=%.4f;18d=0;19d=0;20d=0;TAS=%.2f;Flares=%s;Chaff=%s", t, obj.Name, myselfData, RPM,  velocityVectors, altAgl, "000", CannonShells, AccelerationUnits, IAS, windVelocityVectors, altAsl, aoa, PayloadInfo, M_number, tas, CM.flare, CM.chaff)
-
-            -- FA-18C sends to SimShaker
+            -- FA-18C sends to TelemFFB
             stringToSend =
-              string.format(
-              "T=%.3f;N=%s;SelfData=%s;Engine_RPM=%s;VlctVectors=%s;altAgl=%.2f;PanShake=%s;Gun=%s;ACCs=%s;d10=0;IAS=%.2f;Wind=%s;altASL=%.2f;AoA=%.2f;PayloadInfo=%s;16d=0;M=%.4f;18d=0;19d=0;20d=0;TAS=%.2f;Flares=%s;Chaff=%s",
-              t,
-              obj.Name,
-              myselfData,
-              RPM,
-              velocityVectors,
-              altAgl,
-              "000",
-              CannonShells,
-              AccelerationUnits,
-              IAS,
-              windVelocityVectors,
-              altAsl,
-              aoa,
-              PayloadInfo,
-              M_number,
-              tas,
-              CM.flare,
-              CM.chaff
-            )
+				string.format(
+				"T=%.3f;N=%s;SelfData=%s;Engine_RPM=%s;VlctVectors=%s;altAgl=%.2f;PanShake=%s;Gun=%s;ACCs=%s;d10=0;IAS=%.2f;Wind=%s;altASL=%.2f;AoA=%.2f;PayloadInfo=%s;16d=0;M=%.4f;18d=0;19d=0;20d=0;TAS=%.2f;Flares=%s;Chaff=%s",
+				t,
+				obj.Name,
+				myselfData,
+				RPM,
+				velocityVectors,
+				altAgl,
+				"000",
+				CannonShells,
+				AccelerationUnits,
+				IAS,
+				windVelocityVectors,
+				altAsl,
+				aoa,
+				PayloadInfo,
+				M_number,
+				tas,
+				CM.flare,
+				CM.chaff
+				)
+
+
+            
           elseif string.find(obj.Name, "F-14") then
             -------------------------------------------------------------------------------------------------------------------------------------------------------
             --local sensor_data = obj.get_base_data()
@@ -916,14 +912,19 @@ local f_telemFFB = {
 -------------------------------------------------------------------------------------------------------------------------------------------------------
           elseif obj.Name == "Christen Eagle II" then
 
-          -- Christen Eagle II sends to SimShaker
-          stringToSend=string.format("T=%.3f;N=%s;SelfData=%s;Engine_RPM=%.2f;VlctVectors=%s;altAgl=%.2f;PanShake=%s;Gun=%s;ACCs=%s;d10=0;IAS=%.2f;Wind=%s;altASL=%.2f;AoA=%.2f;PayloadInfo=%s;16d=0;M=%.4f;18d=0;19d=0;20d=0;TAS=%.2f;Flares=%s;Chaff=%s", t, obj.Name, myselfData, "0",  velocityVectors, altAgl, "000", CannonShells, AccelerationUnits, IAS, windVelocityVectors, altAsl, aoa, PayloadInfo, M_number, tas, CM.flare, CM.chaff)
+			-- Christen Eagle II sends to SimShaker
+			stringToSend=string.format("T=%.3f;N=%s;SelfData=%s;Engine_RPM=%.2f;VlctVectors=%s;altAgl=%.2f;PanShake=%s;Gun=%s;ACCs=%s;d10=0;IAS=%.2f;Wind=%s;altASL=%.2f;AoA=%.2f;PayloadInfo=%s;16d=0;M=%.4f;18d=0;19d=0;20d=0;TAS=%.2f;Flares=%s;Chaff=%s", t, obj.Name, myselfData, "0",  velocityVectors, altAgl, "000", CannonShells, AccelerationUnits, IAS, windVelocityVectors, altAsl, aoa, PayloadInfo, M_number, tas, CM.flare, CM.chaff)
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------
           elseif obj.Name == "MiG-19P" then
 
-          -- MiG-19P sends to SimShaker
-          stringToSend=string.format("T=%.3f;N=%s;SelfData=%s;Engine_RPM=%.2f;VlctVectors=%s;altAgl=%.2f;PanShake=%s;Gun=%s;ACCs=%s;d10=0;IAS=%.2f;Wind=%s;altASL=%.2f;AoA=%.2f;PayloadInfo=%s;16d=0;M=%.4f;18d=0;19d=0;20d=0;TAS=%.2f;Flares=%s;Chaff=%s", t, obj.Name, myselfData, "0",  velocityVectors, altAgl, "000", CannonShells, AccelerationUnits, IAS, windVelocityVectors, altAsl, aoa, PayloadInfo, M_number, tas, CM.flare, CM.chaff)
+			-- MiG-19P sends to SimShaker
+			stringToSend=string.format("T=%.3f;N=%s;SelfData=%s;Engine_RPM=%.2f;VlctVectors=%s;altAgl=%.2f;PanShake=%s;Gun=%s;ACCs=%s;d10=0;IAS=%.2f;Wind=%s;altASL=%.2f;AoA=%.2f;PayloadInfo=%s;16d=0;M=%.4f;18d=0;19d=0;20d=0;TAS=%.2f;Flares=%s;Chaff=%s", t, obj.Name, myselfData, "0",  velocityVectors, altAgl, "000", CannonShells, AccelerationUnits, IAS, windVelocityVectors, altAsl, aoa, PayloadInfo, M_number, tas, CM.flare, CM.chaff)
+		
+		  elseif obj.Name == "F-15ESE" then
+
+			-- F15 sends to TelemFFB
+			stringToSend=string.format("T=%.3f;N=%s;SelfData=%s;Engine_RPM=%.2f;VlctVectors=%s;altAgl=%.2f;PanShake=%s;Gun=%s;ACCs=%s;d10=0;IAS=%.2f;Wind=%s;altASL=%.2f;AoA=%.2f;PayloadInfo=%s;16d=0;M=%.4f;18d=0;19d=0;20d=0;TAS=%.2f;Flares=%s;Chaff=%s", t, obj.Name, myselfData, "0",  velocityVectors, altAgl, "000", CannonShells, AccelerationUnits, IAS, windVelocityVectors, altAsl, aoa, PayloadInfo, M_number, tas, CM.flare, CM.chaff)
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------
           else -- FC3 Planes
@@ -978,8 +979,19 @@ local f_telemFFB = {
               CM.chaff
             )
           end
-
-          stringToSend = string.format("%s;WeightOnWheels=%s;MechInfo=%s", stringToSend, WoW, mech)
+		  
+		stringToSend = 
+			string.format(
+			"%s;WeightOnWheels=%s;CanopyPos=%s;SpeedbrakePos=%s;FlapsPos=%s;GearPos=%s;FuelProbePos=%s;MechInfo=%s",
+			stringToSend,
+			WoW,
+			LoGetMechInfo().canopy.value,
+			LoGetMechInfo().speedbrakes.value,
+			LoGetMechInfo().flaps.value,
+			LoGetMechInfo().gear.value,
+			LoGetMechInfo().refuelingboom.value,
+			mech
+		  )
 
           socket.try(self.sock_udp:send(stringToSend))
         end

--- a/main.py
+++ b/main.py
@@ -58,9 +58,18 @@ parser.add_argument('-p', '--plot', type=str, nargs='+',
 
 parser.add_argument('-D', '--device', type=str, help='Rhino device USB VID:PID', default="ffff:2055")
 
+# Add config file argument, default config.ini
+parser.add_argument('-c', '--configfile', type=str, help='Config ini file (default config.ini)', default="config.ini")
+
 args = parser.parse_args()
 
-config_path = os.path.join(os.path.dirname(__file__), "config.ini")
+# Use config file arguement in config_path
+config_path = os.path.join(os.path.dirname(__file__), args.configfile)
+
+# Log config file error here as try-except below does not catch missing file (no operations done on file that would trigger exception)
+if not os.path.exists(config_path):
+    logging.error(f"Failed to load Config: {config_path}")
+    
 try:
     config = ConfigObj(config_path)
     logging.info(f"Using Config: {config_path}")


### PR DESCRIPTION
Added argument for cfg file so those with multiple VPF devices can create profiles for each peripheral and start multiple instances of TelemFFB pointing to different config files

Added support for configuring the direction of force during the payload release, gunfire and countermeasure release events.  Settings is configurable between 0-360 degrees or if set to -1, the force direction will be random, causing the stick to wander around center while the trigger is held.