### PR TITLE
G-Load effect | file logging | MSFS config option | bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Also this early version is very bare-bones and community-driven development is v
 - Helicopter effective translational lift (ETL) effects.
 - Shows a debug window that displays the received telemetry data.
 
+## Executable Versions
+If you are not git-savy or simply dont want to deal with python, git, and cloning repositories and would rather just use an all-in-one executable distribution...
+
+- The main (stable) branch release version is available here:   https://github.com/walmis/VPforce-TelemFFB/releases
+- The development (possibly unstable) branch auto-builds are available here after each commit to the repository: https://vpforcecontrols.com/downloads/TelemFFB/?C=M;O=A
 ## Development
 
 - This framework is made to be very easy to manage FFB effect lifecycles and develop additional effects or specialize specific aircraft effects.

--- a/aircrafts_dcs.py
+++ b/aircrafts_dcs.py
@@ -250,6 +250,7 @@ class Aircraft(AircraftBase):
             # If effect direction is set to random (-1) in ini file, randomize direction - else, use configured direction (default=45)
             if self.weapon_effect_direction == -1:
                 #Init random number for effect direction
+                random.seed(time.perf_counter())
                 random_weapon_release_direction = random.randint(0, 359)
                 logging.info(f"Payload Effect Direction is randomized: {random_weapon_release_direction} deg")
                 effects["cm"].periodic(10, self.weapon_release_intensity, random_weapon_release_direction, duration=80).start()
@@ -261,6 +262,7 @@ class Aircraft(AircraftBase):
             # If effect direction is set to random (-1) in ini file, randomize direction - else, use configured direction (default=45)
             if self.weapon_effect_direction == -1:
                 #Init random number for effect direction
+                random.seed(time.perf_counter())
                 random_weapon_release_direction = random.randint(0, 359)
                 logging.info(f"Gun Effect Direction is randomized: {random_weapon_release_direction} deg")
                 effects["cm"].periodic(10, self.gun_vibration_intensity, random_weapon_release_direction, duration=80).start()
@@ -272,6 +274,7 @@ class Aircraft(AircraftBase):
             # If effect direction is set to random (-1) in ini file, randomize direction - else, use configured direction (default=45)
             if self.weapon_effect_direction == -1:
                 #Init random number for effect direction
+                random.seed(time.perf_counter())
                 random_weapon_release_direction = random.randint(0, 359)
                 logging.info(f"CM Effect Direction is randomized: {random_weapon_release_direction} deg")
                 effects["cm"].periodic(50, self.cm_vibration_intensity, random_weapon_release_direction, duration=80).start()

--- a/aircrafts_dcs.py
+++ b/aircrafts_dcs.py
@@ -89,6 +89,7 @@ class Aircraft(AircraftBase):
     #### Beta effects - set to 1 to enable
     gforce_effect_enable = 0
     gforce_effect_enable_areyoureallysure = 0
+    gforce_effect_curvature = 2.2
     gforce_effect_max_intensity = 1.0
     gforce_min_gs = 1.5  # G's where the effect starts playing
     gforce_max_gs = 5.0  # G limit where the effect maxes out at strength defined in gforce_effect_max_intensity
@@ -151,7 +152,8 @@ class Aircraft(AircraftBase):
             effects.dispose("gforce")
             effects.dispose("gforce_damper")
             return
-        g_factor = round(utils.scale(z_gs, (gmin, gmax), (0, self.gforce_effect_max_intensity)), 3)
+        #g_factor = round(utils.scale(z_gs, (gmin, gmax), (0, self.gforce_effect_max_intensity)), 4)
+        g_factor = round(utils.non_linear_scaling(z_gs, gmin, gmax, curvature=self.gforce_effect_curvature),4)
         g_factor = utils.clamp(g_factor, 0.0, 1.0)
         effects["gforce"].constant(g_factor, 180).start()
       #  effects["gforce_damper"].damper(coef_y=1024).start()

--- a/aircrafts_dcs.py
+++ b/aircrafts_dcs.py
@@ -139,6 +139,7 @@ class Aircraft(AircraftBase):
 
 
     def _gforce_effect(self, telem_data):
+
        # gforce_effect_enable = 1
         gneg = -1.0
         gmin = self.gforce_min_gs
@@ -148,9 +149,13 @@ class Aircraft(AircraftBase):
         z_gs : float = telem_data.get("ACCs")[1]
         if z_gs < gmin:
             effects.dispose("gforce")
+            effects.dispose("gforce_damper")
             return
         g_factor = round(utils.scale(z_gs, (gmin, gmax), (0, self.gforce_effect_max_intensity)), 3)
+        g_factor = utils.clamp(g_factor, 0.0, 1.0)
         effects["gforce"].constant(g_factor, 180).start()
+      #  effects["gforce_damper"].damper(coef_y=1024).start()
+
         logging.debug(f"G's = {z_gs} | gfactor = {g_factor}")
 
     def _decel_effect(self, telem_data):

--- a/config.ini
+++ b/config.ini
@@ -80,7 +80,6 @@ runway_rumble_intensity = 1.0
 engine_rumble = 1 # rumble based on RPM
 engine_rumble_lowrpm_intensity = 0.05
 gear_buffet_intensity = 0.10
-rpm_scale = 31.5 # RPM% to actual RPM scale
 
 [P-51D]
 type=PropellerAircraft

--- a/config.ini
+++ b/config.ini
@@ -61,7 +61,7 @@ deceleration_max_force = 0.5
 gforce_effect_enable = 0
 gforce_effect_enable_areyoureallysure = 0
 gforce_effect_max_intensity = 1.0
-gforce_min_gs = 1.5 # G's where the effect starts playing
+gforce_min_gs = 1.3 # G's where the effect starts playing
 gforce_max_gs = 5.0 # G limit where the effect maxes out at strength defined in gforce_effect_max_intensity
 
 ################

--- a/config.ini
+++ b/config.ini
@@ -1,6 +1,6 @@
 [system]
-logging_level = DEBUG                   # DEBUG | INFO | WARNING | ERROR | CRITICAL
-msfs_enabled = 0                        # 0=disable, 1=enable
+logging_level = INFO                   # DEBUG | INFO | WARNING | ERROR | CRITICAL (case sensitive)
+msfs_enabled = 0                       # 0=disable, 1=enable
 
 [default]
 type=Aircraft							# Valid Types 'Aircraft' | 'PropellerAircraft' | 'JetAircraft' | 'Helicopter'
@@ -14,19 +14,19 @@ stall_aoa           = 15				# Stall AoA (default 15)
 runway_rumble_intensity = 1.0			# peak runway intensity, 0 to disable (default 1.0)
 gun_vibration_intensity = 12%			# peak intenstiy for gunfire effect, 0 to disable (default 0.12)
 cm_vibration_intensity = 12%			# peak intensity for countermeasure release effect, 0 to disable (default 0.12)
-weapon_release_intensity = 12%		# peak intensity for weapons release effect, 0 to disable (default 0.12)
+weapon_release_intensity = 12%		    # peak intensity for weapons release effect, 0 to disable (default 0.12)
 
 #########################################
 # **NEW** settings from Number481 below #
 #########################################
-weapon_effect_direction = 45			# Direction of applied force for gunfire/cm/weapon effects | range 0-359 or set to -1 for random  (default 45)
+weapon_effect_direction = -1			# Direction of applied force for gunfire/cm/weapon effects | range 0-359 or set to -1 for random
 
 ####Movement Effects (DISABLED BY DEFAULT) - Uncomment to enable or add to a specific aircraft section
 #### These effects default to 0.0 in the code, uncomment a line (or add to an aircraft section) to enable
 
 speedbrake_motion_intensity = 20%       # peak vibration intensity when speed brake is moving, 0 to disable
 gear_motion_intensity = 20%			    # peak vibration intensity when gear is moving, 0 to disable
-flaps_motion_intensity = 0.0			# peak vibration intensity when flaps are moving, 0 to disable (!! DISABLED BY DEFAULT)
+flaps_motion_intensity = 0.0			# peak vibration intensity when flaps are moving, 0 to disable
 canopy_motion_intensity = 12% 		    # peak vibration intensity when canopy is moving, 0 to disable
 
 speedbrake_buffet_intensity = 15%       #Peak intensity for speed brake buffeting effect - recommend 0.15
@@ -36,25 +36,25 @@ gear_buffet_intensity = 15%             #Peak intensity for gear drag buffeting 
 ### Effect intensity will vary linearly between 'lowrpm_intensity' and 'highrpm_intensity' with engine RPM between 'lowrpm' and 'highrpm'
 ### Effect intensity will lessen as RPM increases
 
-engine_rumble = 1						# Enable rumble effect (default = 0 (disabled)) - Valid options '1' (enabled) or '0' (disabled) - recommend to enable on per aircraft basis
-engine_rumble_lowrpm = 450				# low RPM threshold for low rpm intensity setting
-engine_rumble_lowrpm_intensity = 0.1	# peak intenstiy of engine rumble at low RPM threshold
+engine_rumble = 0						# Enable rumble effect (default = 0 (disabled)) - Valid options '1' (enabled) or '0' (disabled) - recommend to enable on per aircraft basis
+engine_rumble_lowrpm = 650				# low RPM threshold for low rpm intensity setting
+engine_rumble_lowrpm_intensity = 0.05	# peak intenstiy of engine rumble at low RPM threshold
 engine_rumble_highrpm = 2800			# high RPM threshold for high rpm intensity setting
-engine_rumble_highrpm_intensity = 0.04	# peak intensity of engine rumble at high RPM threshold
+engine_rumble_highrpm_intensity = 0.03	# peak intensity of engine rumble at high RPM threshold
 
 ## Afterburner effect now supported on all AB equipped aircraft
 ## Tested on F/A-18, F-16, F-15E
 ## Edit here to change globally, or add to specific aircraft entry below
 afterburner_effect_intensity = 0.2
-jet_engine_rumble_intensity = 0.05
+jet_engine_rumble_intensity = 0.00      # Maximum intensity for jet engine rumble effect.  Set to 0 to disable.  recommend to enable on per aircraft basis
 jet_engine_rumble_freq = 45             # base frequency for jet engine rumble effect (Hz)
 
 ## Spoiler effect - only supported for F14 DLC
-spoiler_motion_intensity = 0.0  # peak vibration intensity when spoilers is moving, 0 to disable
-spoiler_buffet_intensity = 0.2  # peak buffeting intensity when spoilers deployed,  0 to disable
+spoiler_motion_intensity = 0.0          # peak vibration intensity when spoilers is moving, 0 to disable
+spoiler_buffet_intensity = 0.2          # peak buffeting intensity when spoilers deployed,  0 to disable
 
 ## Helicopter Engine/Rotor Rumble effect
-heli_engine_rumble_intensity = 0.12 # peak rumble intensity for helicopter engine/rotor effect
+heli_engine_rumble_intensity = 0.12     # peak rumble intensity for helicopter engine/rotor effect
 
 ## Beta feature - use at own risk, keep firm grip on stick while decelerating or carrier landing!
 deceleration_effect_enable = 0
@@ -64,10 +64,10 @@ deceleration_max_force = 0.5
 ## Beta feature - use at own risk, keep firm grip on stick while enabled.  Makes Y axis fan go brrrrrrrttt
 gforce_effect_enable = 0
 gforce_effect_enable_areyoureallysure = 0
-gforce_effect_curvature = 2.2  #adjust the onset characteristics of the effect
-gforce_effect_max_intensity = 1.0
-gforce_min_gs = 1.3 # G's where the effect starts playing
-gforce_max_gs = 6.0 # G limit where the effect maxes out at strength defined in gforce_effect_max_intensity
+gforce_effect_curvature = 2.2           #adjust the onset characteristics of the effect
+gforce_effect_max_intensity = 0.8
+gforce_min_gs = 1.5                     # G's where the effect starts playing
+gforce_max_gs = 6.5                     # G limit where the effect maxes out at strength defined in gforce_effect_max_intensity
 
 ################
 ### Props   ####
@@ -78,7 +78,8 @@ type=PropellerAircraft
 buffeting_intensity = 0.0 # implemented by DCS
 runway_rumble_intensity = 1.0
 engine_rumble = 1 # rumble based on RPM
-gear_buffet_intensity = 0.15
+engine_rumble_lowrpm_intensity = 0.05
+gear_buffet_intensity = 0.10
 rpm_scale = 31.5 # RPM% to actual RPM scale
 
 [P-51D]
@@ -86,40 +87,48 @@ type=PropellerAircraft
 buffeting_intensity = 0.0 # implemented by DCS
 runway_rumble_intensity = 1.0
 engine_rumble = 1 # rumble based on RPM
-gear_buffet_intensity = 0.15
+engine_rumble_lowrpm_intensity = 0.05
+gear_buffet_intensity = 0.10
 
 [P-47D-30]
 type=PropellerAircraft
 engine_rumble = 1 # rumble based on RPM
-gear_buffet_intensity = 0.15
+engine_rumble_lowrpm_intensity = 0.05
+gear_buffet_intensity = 0.10
 
 [SpitfireLFMkIX]
 type=PropellerAircraft
 engine_rumble = 1 # rumble based on RPM
-gear_buffet_intensity = 0.15
+engine_rumble_lowrpm_intensity = 0.05
+gear_buffet_intensity = 0.10
 
 [FW-190A8]
 type=PropellerAircraft
 engine_rumble = 1 # rumble based on RPM
-gear_buffet_intensity = 0.15
+engine_rumble_lowrpm_intensity = 0.05
+gear_buffet_intensity = 0.10
 
 [FW-190D9]
 type=PropellerAircraft
 buffeting_intensity = 0.0 # implemented by DCS
 runway_rumble_intensity = 1.0
 engine_rumble = 1 # rumble based on RPM
-gear_buffet_intensity = 0.15
+engine_rumble_lowrpm_intensity = 0.05
+gear_buffet_intensity = 0.10
 
 [Bf-109K-4]
 type = PropellerAircraft
+engine_rumble_lowrpm_intensity = 0.05
 
 [I-16]
 type=PropellerAircraft
 engine_rumble = 1 # rumble based on RPM
+engine_rumble_lowrpm_intensity = 0.05
 
 [MosquitoFBMkVI]
 type=PropellerAircraft
 engine_rumble = 1
+engine_rumble_lowrpm_intensity = 0.05
 
 ################
 ####  Jets  ####
@@ -129,37 +138,45 @@ engine_rumble = 1
 type=JetAircraft
 runway_rumble_intensity=3.0
 flaps_motion_intensity = 0.0
-speedbrake_buffet_intensity = 0.15
+speedbrake_buffet_intensity = 0.08
 gear_buffet_intensity = 0.15
+jet_engine_rumble_intensity = 0.05
 
 [F-16C_50]
 type=JetAircraft
 runway_rumble_intensity=3.0
 flaps_motion_intensity = 0.0
-speedbrake_buffet_intensity = 0.15
+speedbrake_buffet_intensity = 0.08
 gear_buffet_intensity = 0.15
+jet_engine_rumble_intensity = 0.05
 
 [F-15ESE]
 type=JetAircraft
 runway_rumble_intensity=2.0
-speedbrake_buffet_intensity = 0.15
+flaps_motion_intensity = 0.0
+speedbrake_buffet_intensity = 0.08
 gear_buffet_intensity = 0.15
+jet_engine_rumble_intensity = 0.05
 
 [MiG-21.*]
 type=JetAircraft
 buffet_aoa = 8
 buffeting_intensity = 0.25
+jet_engine_rumble_intensity = 0.05
 
 [MiG-29.*]
 type=JetAircraft
+jet_engine_rumble_intensity = 0.05
 
 [Su-25.*]
 type=JetAircraft
 buffeting_intensity = 0 # Handled by DCS
+jet_engine_rumble_intensity = 0.05
 
 [Su-33]
 type=JetAircraft
 runway_rumble_intensity=2.0
+jet_engine_rumble_intensity = 0.05
 
 [F-14*]
 type=JetAircraft
@@ -171,34 +188,42 @@ runway_rumble_intensity=2.0
 [AV8BNA]
 type=JetAircraft
 runway_rumble_intensity=2.0
+jet_engine_rumble_intensity = 0.05
 
 [M-2000C]
 type=JetAircraft
 runway_rumble_intensity=2.0
+jet_engine_rumble_intensity = 0.05
 
 [Mirage_F1]
 type=JetAircraft
 runway_rumble_intensity=2.0
+jet_engine_rumble_intensity = 0.05
 
 [JF-17]
 type=JetAircraft
 runway_rumble_intensity=2.0
+jet_engine_rumble_intensity = 0.05
 
 [MB-339*]
 type=JetAircraft
 runway_rumble_intensity=2.0
+jet_engine_rumble_intensity = 0.05
 
 [A-10C*]
 type=JetAircraft
 runway_rumble_intensity=2.0
+jet_engine_rumble_intensity = 0.05
 
 [AJS37]
 type=JetAircraft
 runway_rumble_intensity=2.0
+jet_engine_rumble_intensity = 0.05
 
 [F-5E]
 type=JetAircraft
 runway_rumble_intensity=2.0
+jet_engine_rumble_intensity = 0.05
 
 
 
@@ -218,8 +243,17 @@ overspeed_shake_intensity = 0.2
 [Mi-8MT]
 type=Helicopter
 
+#Made by user Reed (jreed4817)
 [SA342.*]
 type=Helicopter
+etl_start_speed = 7 # m/s
+etl_stop_speed = 14 # m/s
+etl_effect_intensity = 0.3 # [ 0.0 .. 1.0]
+overspeed_shake_start = 75 # m/s
+overspeed_shake_intensity = 0.25
+gun_vibration_intensity = 0.2
+cm_vibration_intensity = 0.15
+weapon_release_intensity = 0.2
 
 [Mi-24P]
 type=Helicopter

--- a/config.ini
+++ b/config.ini
@@ -1,6 +1,6 @@
 [system]
-logging_level = DEBUG
-msfs_enabled = 0
+logging_level = DEBUG                   # DEBUG | INFO | WARNING | ERROR | CRITICAL
+msfs_enabled = 0                        # 0=disable, 1=enable
 
 [default]
 type=Aircraft							# Valid Types 'Aircraft' | 'PropellerAircraft' | 'JetAircraft' | 'Helicopter'

--- a/config.ini
+++ b/config.ini
@@ -57,12 +57,13 @@ deceleration_effect_enable = 0
 deceleration_effect_enable_areyoureallysure = 0
 deceleration_max_force = 0.5
 
-## Beta feature - use at own risk, keep firm grip on stick while enabled
+## Beta feature - use at own risk, keep firm grip on stick while enabled.  Makes Y axis fan go brrrrrrrttt
 gforce_effect_enable = 0
 gforce_effect_enable_areyoureallysure = 0
+gforce_effect_curvature = 2.2  #adjust the onset characteristics of the effect
 gforce_effect_max_intensity = 1.0
 gforce_min_gs = 1.3 # G's where the effect starts playing
-gforce_max_gs = 5.0 # G limit where the effect maxes out at strength defined in gforce_effect_max_intensity
+gforce_max_gs = 6.0 # G limit where the effect maxes out at strength defined in gforce_effect_max_intensity
 
 ################
 ### Props   ####

--- a/config.ini
+++ b/config.ini
@@ -1,3 +1,7 @@
+[system]
+logging_level = DEBUG
+msfs_enabled = 0
+
 [default]
 type=Aircraft							# Valid Types 'Aircraft' | 'PropellerAircraft' | 'JetAircraft' | 'Helicopter'
 ## Default Settings below 

--- a/config.ini
+++ b/config.ini
@@ -53,8 +53,8 @@ spoiler_buffet_intensity = 0.2  # peak buffeting intensity when spoilers deploye
 heli_engine_rumble_intensity = 0.12 # peak rumble intensity for helicopter engine/rotor effect
 
 ## Beta feature - use at own risk, keep firm grip on stick while decelerating or carrier landing!
-deceleration_effect_enable = 1
-deceleration_effect_enable_areyoureallysure = 1
+deceleration_effect_enable = 0
+deceleration_effect_enable_areyoureallysure = 0
 deceleration_max_force = 0.5
 ################
 ### Props   ####

--- a/config.ini
+++ b/config.ini
@@ -56,6 +56,14 @@ heli_engine_rumble_intensity = 0.12 # peak rumble intensity for helicopter engin
 deceleration_effect_enable = 0
 deceleration_effect_enable_areyoureallysure = 0
 deceleration_max_force = 0.5
+
+## Beta feature - use at own risk, keep firm grip on stick while enabled
+gforce_effect_enable = 0
+gforce_effect_enable_areyoureallysure = 0
+gforce_effect_max_intensity = 1.0
+gforce_min_gs = 1.5 # G's where the effect starts playing
+gforce_max_gs = 5.0 # G limit where the effect maxes out at strength defined in gforce_effect_max_intensity
+
 ################
 ### Props   ####
 ################

--- a/main.py
+++ b/main.py
@@ -492,13 +492,8 @@ def main():
             "CRITICAL": logging.CRITICAL,
         }
         logger.setLevel(log_levels.get(ll, logging.DEBUG))
-        logging.info(f"Setting logging level to:{ll}")
-        logging.debug("Test Debug Log")
-        logging.info("Test Info Log")
-        logging.warning("Test Warning Log")
-        logging.error("Test Error Log")
-        logging.critical("Test Critical Log")
-    except: 
+        logging.critical(f"Logging level set to:{logging.getLevelName(logger.getEffectiveLevel())}")
+    except:
         logging.exception(f"Cannot load config {config_path}")
 
 
@@ -511,8 +506,9 @@ def main():
     manager.telemetryReceived.connect(window.update_telemetry)
 
     sc = SimConnectSock()
-    msfs = config["system"].get("msfs_enabled", 0)
-    if msfs == 1:
+    msfs = config["system"].get("msfs_enabled", None)
+    logging.debug(f"MSFS={msfs}")
+    if msfs == "1":
         logging.info("MSFS Enabled in config:  Starting Simconnect Manager")
         sc.start()
 

--- a/main.py
+++ b/main.py
@@ -20,39 +20,8 @@ import logging
 import sys
 import time
 import os
-sys.path.insert(0, '')
-
-log_folder = './log'
-
-if not os.path.exists(log_folder):
-    os.makedirs(log_folder)
-
-log_file = os.path.join(log_folder, 'TelemFFB.log')
-
-# Create a logger instance
-logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
-
-# Create a formatter for the log messages
-formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
-
-# Create a StreamHandler to log messages to the console
-console_handler = logging.StreamHandler(sys.stdout)
-console_handler.setLevel(logging.DEBUG)
-console_handler.setFormatter(formatter)
-
-# Create a FileHandler to log messages to the log file
-file_handler = logging.FileHandler(log_file, mode='w')
-file_handler.setLevel(logging.DEBUG)
-file_handler.setFormatter(formatter)
-
-# Add the handlers to the logger
-logger.addHandler(console_handler)
-logger.addHandler(file_handler)
-
-
 import re
-  
+
 import argparse
 from PyQt5 import QtWidgets
 from PyQt5.QtWidgets import QApplication, QWidget, QLabel, QMainWindow, QVBoxLayout, QMessageBox, QPushButton, QDialog, \
@@ -98,6 +67,36 @@ parser.add_argument('-r', '--reset', help='Reset all FFB effects', action='store
 parser.add_argument('-c', '--configfile', type=str, help='Config ini file (default config.ini)', default="config.ini")
 
 args = parser.parse_args()
+sys.path.insert(0, '')
+
+log_folder = './log'
+if not os.path.exists(log_folder):
+    os.makedirs(log_folder)
+logname = "".join(["TelemFFB", "_", args.device.replace(":", "-"), "_", args.configfile, ".log"])
+log_file = os.path.join(log_folder, logname)
+
+# Create a logger instance
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+
+# Create a formatter for the log messages
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
+
+# Create a StreamHandler to log messages to the console
+console_handler = logging.StreamHandler(sys.stdout)
+console_handler.setLevel(logging.DEBUG)
+console_handler.setFormatter(formatter)
+
+# Create a FileHandler to log messages to the log file
+file_handler = logging.FileHandler(log_file, mode='w')
+file_handler.setLevel(logging.DEBUG)
+file_handler.setFormatter(formatter)
+
+# Add the handlers to the logger
+logger.addHandler(console_handler)
+logger.addHandler(file_handler)
+
+
 
 if args.teleplot:
     logging.info(f"Using {args.teleplot} for plotting")

--- a/main.py
+++ b/main.py
@@ -19,14 +19,37 @@ import json
 import logging
 import sys
 import time
-sys.path.insert(0, '') 
+import os
+sys.path.insert(0, '')
 
-logging.basicConfig(
-    level=logging.DEBUG,
-    format='%(asctime)s - %(levelname)s - %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S',
-    stream=sys.stdout,
-)
+log_folder = './log'
+
+if not os.path.exists(log_folder):
+    os.makedirs(log_folder)
+
+log_file = os.path.join(log_folder, 'TelemFFB.log')
+
+# Create a logger instance
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+
+# Create a formatter for the log messages
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
+
+# Create a StreamHandler to log messages to the console
+console_handler = logging.StreamHandler(sys.stdout)
+console_handler.setLevel(logging.DEBUG)
+console_handler.setFormatter(formatter)
+
+# Create a FileHandler to log messages to the log file
+file_handler = logging.FileHandler(log_file, mode='w')
+file_handler.setLevel(logging.DEBUG)
+file_handler.setFormatter(formatter)
+
+# Add the handlers to the logger
+logger.addHandler(console_handler)
+logger.addHandler(file_handler)
+
 
 import re
   
@@ -460,6 +483,21 @@ def main():
         global config
         config = ConfigObj(config_path)
         logging.info(f"Using Config: {config_path}")
+        ll = config["system"].get("logging_level", "INFO")
+        log_levels = {
+            "DEBUG": logging.DEBUG,
+            "INFO": logging.INFO,
+            "WARNING": logging.WARNING,
+            "ERROR": logging.ERROR,
+            "CRITICAL": logging.CRITICAL,
+        }
+        logger.setLevel(log_levels.get(ll, logging.DEBUG))
+        logging.info(f"Setting logging level to:{ll}")
+        logging.debug("Test Debug Log")
+        logging.info("Test Info Log")
+        logging.warning("Test Warning Log")
+        logging.error("Test Error Log")
+        logging.critical("Test Critical Log")
     except: 
         logging.exception(f"Cannot load config {config_path}")
 
@@ -473,7 +511,10 @@ def main():
     manager.telemetryReceived.connect(window.update_telemetry)
 
     sc = SimConnectSock()
-    #sc.start()
+    msfs = config["system"].get("msfs_enabled", 0)
+    if msfs == 1:
+        logging.info("MSFS Enabled in config:  Starting Simconnect Manager")
+        sc.start()
 
 
     app.exec_()

--- a/main.py
+++ b/main.py
@@ -14,43 +14,7 @@
 # You should have received a copy of the GNU General Public License 
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-
-import json
-import logging
-import sys
-import time
-import os
-import re
-
 import argparse
-from PyQt5 import QtWidgets
-from PyQt5.QtWidgets import QApplication, QWidget, QLabel, QMainWindow, QVBoxLayout, QMessageBox, QPushButton, QDialog, \
-    QRadioButton, QListView, QScrollArea
-from PyQt5.QtCore import QObject, pyqtSignal, Qt, QCoreApplication, QUrl, QRect, QMetaObject
-from PyQt5.QtGui import QFont, QPixmap, QIcon, QDesktopServices
-# from PyQt5.QtWidgets import *
-# from PyQt5.QtCore import *
-# from PyQt5.QtGui import *
-
-from time import monotonic
-import socket
-import threading
-import aircrafts_dcs
-import aircrafts_msfs
-import utils
-import subprocess
-
-import traceback
-import os
-from ffb_rhino import HapticEffect
-from configobj import ConfigObj
-
-from sc_manager import SimConnectManager
-
-config : ConfigObj = None
-
-script_dir = os.path.dirname(os.path.abspath(__file__))
-
 parser = argparse.ArgumentParser(description='Send telemetry data over USB')
 
 # Add destination telemetry address argument
@@ -67,6 +31,11 @@ parser.add_argument('-r', '--reset', help='Reset all FFB effects', action='store
 parser.add_argument('-c', '--configfile', type=str, help='Config ini file (default config.ini)', default="config.ini")
 
 args = parser.parse_args()
+import json
+import logging
+import sys
+import time
+import os
 sys.path.insert(0, '')
 
 log_folder = './log'
@@ -96,7 +65,34 @@ file_handler.setFormatter(formatter)
 logger.addHandler(console_handler)
 logger.addHandler(file_handler)
 
+import re
 
+from PyQt5 import QtWidgets
+from PyQt5.QtWidgets import QApplication, QWidget, QLabel, QMainWindow, QVBoxLayout, QMessageBox, QPushButton, QDialog, \
+    QRadioButton, QListView, QScrollArea
+from PyQt5.QtCore import QObject, pyqtSignal, Qt, QCoreApplication, QUrl, QRect, QMetaObject
+from PyQt5.QtGui import QFont, QPixmap, QIcon, QDesktopServices
+# from PyQt5.QtWidgets import *
+# from PyQt5.QtCore import *
+# from PyQt5.QtGui import *
+
+from time import monotonic
+import socket
+import threading
+import aircrafts_dcs
+import aircrafts_msfs
+import utils
+import subprocess
+
+import traceback
+from ffb_rhino import HapticEffect
+from configobj import ConfigObj
+
+from sc_manager import SimConnectManager
+
+config : ConfigObj = None
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
 
 if args.teleplot:
     logging.info(f"Using {args.teleplot} for plotting")
@@ -491,7 +487,7 @@ def main():
             "CRITICAL": logging.CRITICAL,
         }
         logger.setLevel(log_levels.get(ll, logging.DEBUG))
-        logging.critical(f"Logging level set to:{logging.getLevelName(logger.getEffectiveLevel())}")
+        logging.info(f"Logging level set to:{logging.getLevelName(logger.getEffectiveLevel())}")
     except:
         logging.exception(f"Cannot load config {config_path}")
 


### PR DESCRIPTION
Implemented G-Loading effect
Added logging to file 
Added options in config.ini to externally set the log level and enable/disable MSFS connect code
Fixed issue in gunfire effect with randinit repeatedly returning the same value. Using rand.seed(time.perfcounter) first to provide different seed value for every call