### PR TITLE
Fix cyclic spring gain not showing in UI

### DIFF
--- a/defaults.xml
+++ b/defaults.xml
@@ -853,6 +853,7 @@
 	</defaults>
 	<defaults>
 		<effecttype>spring</effecttype>
+		<value>.5</value>
 		<datatype>float</datatype>
 		<grouping>Basic</grouping>
 		<parentgroup>basic</parentgroup>


### PR DESCRIPTION
Add value 0.5 to cyclic_spring_gain so it shows in UI for force trim helis