### PR TITLE
MSFS/XP - Auto Trim Calibration optimization: direct trim writes, and misbehaving-aircraft diagnostics

### DIFF
--- a/telemffb/IPCNetworkThread.py
+++ b/telemffb/IPCNetworkThread.py
@@ -312,6 +312,14 @@ class IPCNetworkThread(QObject, threading.Thread):
             payload = msg.removeprefix("MASTER_BUTTONS:")
             G.master_buttons = json.loads(payload)
             # print(f"MB: {G.master_buttons}")
+        elif msg.startswith("TRIMCAL HOLD:"):
+            # Master is running a trim calibration: hold/release this
+            # instance's trimwheel sim writes. Refreshed ~1/s while active and
+            # self-expiring, so a crashed master cannot mute the wheel forever.
+            if msg.removeprefix("TRIMCAL HOLD:") == "1":
+                G.trimcal_hold_until = time.perf_counter() + 3.0
+            else:
+                G.trimcal_hold_until = 0.0
         elif msg.startswith("BUTTONS:"):
             payload = msg.removeprefix("BUTTONS:").split("_")
             dev = payload[0]

--- a/telemffb/TrimCalibrationDialog.py
+++ b/telemffb/TrimCalibrationDialog.py
@@ -30,10 +30,11 @@ from PyQt6.QtCore import Qt, pyqtSignal
 from PyQt6.QtWidgets import (
     QDialog, QLabel, QPushButton, QVBoxLayout, QHBoxLayout, QGridLayout,
     QGroupBox, QProgressBar, QMessageBox, QFrame, QCheckBox, QSizePolicy,
+    QComboBox,
 )
 
 import telemffb.globals as G
-from telemffb.custom_widgets import TrimCurveWidget
+from telemffb.custom_widgets import InfoLabel, TrimCurveWidget
 from telemffb.sim.msfs_xp.TrimCalibrator import CalState
 
 logger = logging.getLogger(__name__)
@@ -107,6 +108,28 @@ class TrimCalibrationDialog(QDialog):
             "so the airspeed settles at the current throttle/trim before measuring.\n"
             "Recommended — uncheck for a faster run.")
         root.addWidget(self.chk_settle)
+
+        response_row = QHBoxLayout()
+        lbl_response = InfoLabel(
+            text="Control response:",
+            tooltip=(
+                "Strength of the control inputs used to fly the aircraft during calibration.\n\n"
+                "Normal — most aircraft.\n"
+                "Reduced — sensitive aircraft that porpoise or bounce during stabilization.\n"
+                "Minimal — very sensitive or aerobatic aircraft with light, twitchy pitch.\n\n"
+                "Calibration also reduces its own control gains automatically when it detects\n"
+                "oscillation; this option just starts from a gentler setting. If a run aborts\n"
+                "with a pitch-oscillation error, retry with the next lower setting."))
+        response_row.addWidget(lbl_response)
+        self.cmb_response = QComboBox()
+        self.cmb_response.addItems([
+            "Normal",
+            "Reduced — sensitive aircraft",
+            "Minimal — very sensitive / aerobatic",
+        ])
+        response_row.addWidget(self.cmb_response)
+        response_row.addStretch(1)
+        root.addLayout(response_row)
 
         # Warning banner shown only while the engine is flying the aircraft.
         self.banner = QLabel("⚠  TelemFFB is controlling your aircraft — stay ready to take over")
@@ -393,6 +416,8 @@ class TrimCalibrationDialog(QDialog):
         self.curve.clear()
         self._clear_result_labels()
         cal.settle_before_sweep = self.chk_settle.isChecked()
+        cal.initial_gain_scale = {0: 1.0, 1: 0.5, 2: 0.25}.get(
+            self.cmb_response.currentIndex(), 1.0)
         cal.start()
 
     def _on_stop(self):

--- a/telemffb/TrimCalibrationDialog.py
+++ b/telemffb/TrimCalibrationDialog.py
@@ -87,15 +87,24 @@ class TrimCalibrationDialog(QDialog):
         root = QVBoxLayout(self)
 
         instructions = QLabel(
-            "<b>How to calibrate</b><br>"
-            "1. Get airborne, straight &amp; level, at a stable cruise speed.<br>"
-            "2. <b>Trim the aircraft</b> so it holds level with near-zero stick force — "
-            "starting far out of trim wastes elevator authority during the sweep.<br>"
-            "3. Autopilot <b>OFF</b>, hands <b>OFF</b> the stick.<br>"
-            "4. Press <b>Start</b> — TelemFFB will fly the aircraft while it sweeps the "
-            "elevator trim and measures the required stick input, then recommends a "
-            "trim-following <i>curve</i> (with the equivalent static "
-            "<i>Y&nbsp;Trim&nbsp;Gain&nbsp;Virtual</i> value) to hold the nose level as you trim."
+            "<b>How to calibrate</b>"
+            "<ul style='margin-top:2px; margin-bottom:6px; -qt-list-indent:1;'>"
+            "<li>It is recommended to perform the calibration in <b>clear</b>, <b>calm</b> conditions.</li>"
+            "<li>If you have a hardware device controlling the elevator trim <b>AXIS</b>, you may "
+            "need to disconnect or un-bind it as it may interfere with TelemFFB "
+            "controlling the trim during calibration. (Excludes Vpforce trim-wheel)</li>"
+            "</ul>"
+            "<ol style='margin-top:0px; margin-bottom:0px; -qt-list-indent:1;'>"
+            "<li>Get airborne, straight &amp; level, at a stable cruise speed with "
+            "Autopilot <b>OFF</b>.</li>"
+            "<li><b>Trim the aircraft</b> so it holds level with near-zero stick force — "
+            "starting far out of trim wastes elevator authority during the sweep.</li>"
+            "<li>Press <b>Start</b> and take your hands <b>off</b> the stick — TelemFFB "
+            "will fly the aircraft while it sweeps the elevator trim and measures the "
+            "required stick input, then recommends a trim-following <i>curve</i> (with "
+            "the equivalent static <i>Y&nbsp;Trim&nbsp;Gain&nbsp;Virtual</i> value) to "
+            "hold the nose level as you trim.</li>"
+            "</ol>"
         )
         instructions.setWordWrap(True)
         root.addWidget(instructions)
@@ -158,11 +167,19 @@ class TrimCalibrationDialog(QDialog):
             w.setAlignment(Qt.AlignmentFlag.AlignHCenter)
             grid.addWidget(w, 1, col)
 
-        # State text gets the full row (long per-frame status lines) and the
-        # stage/ready light its own row — sharing a row clips one or the other.
-        grid.addWidget(QLabel("<b>State:</b>"), 2, 0)
+        # State text gets its own full-width row (long per-frame status lines)
+        # and the stage/ready light its own — sharing a row clips one or the
+        # other. An HBox keeps the message left-justified right after the
+        # State: prefix instead of starting at the (wide) second grid column,
+        # and the label reserves two text lines so an occasional word-wrap
+        # cannot bounce the layout below it up and down.
+        state_row = QHBoxLayout()
+        state_row.addWidget(QLabel("<b>State:</b>"), 0, Qt.AlignmentFlag.AlignTop)
         self.lbl_state.setWordWrap(True)
-        grid.addWidget(self.lbl_state, 2, 1, 1, 4)
+        self.lbl_state.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
+        self.lbl_state.setMinimumHeight(2 * self.lbl_state.fontMetrics().lineSpacing())
+        state_row.addWidget(self.lbl_state, 1)
+        grid.addLayout(state_row, 2, 0, 1, 5)
         self.lbl_ready = QLabel("●  —")
         grid.addWidget(self.lbl_ready, 3, 0, 1, 5, alignment=Qt.AlignmentFlag.AlignRight)
 
@@ -188,6 +205,9 @@ class TrimCalibrationDialog(QDialog):
         # a given text branch happens to contain HTML tags for auto-detection.
         self.lbl_virtual.setTextFormat(Qt.TextFormat.RichText)
         self.lbl_linearity.setTextFormat(Qt.TextFormat.RichText)
+        # The recommendation line grows long (curve + static fit + current
+        # value); wrap it instead of pushing past the window edge.
+        self.lbl_virtual.setWordWrap(True)
         self.chk_use_curve = QCheckBox("Use calibrated curve (recommended) — static gain is used when unchecked")
         self.chk_use_curve.setChecked(True)
         self.chk_use_curve.setEnabled(False)
@@ -364,14 +384,29 @@ class TrimCalibrationDialog(QDialog):
         return True
 
     def _fit_to_content(self):
-        """Grow (never shrink) the window so a tall notes block can't overlap
-        the graph. The result text is populated after the dialog is shown, and
-        Qt relayouts within the current window height rather than enlarging it.
+        """Grow (never shrink) the window so the content cannot overlap.
+
+        Word-wrapped labels make the layout height-for-width: a plain
+        sizeHint() under-reports the needed height until a later layout pass,
+        which shows up as text overlapping the graph that fixes itself when
+        the window is moved. Force a layout pass and measure with the
+        height-for-width machinery at the current width instead.
         """
-        self.lbl_note.adjustSize()
-        needed = self.sizeHint().height()
+        lay = self.layout()
+        lay.activate()
+        if lay.hasHeightForWidth():
+            needed = lay.totalHeightForWidth(self.width())
+        else:
+            needed = self.sizeHint().height()
         if self.height() < needed:
             self.resize(self.width(), needed)
+
+    def _refit(self):
+        """Fit now and once more on the next event-loop tick: the deferred
+        pass re-measures after Qt has finished the pending relayout (the same
+        settling a window move used to trigger by accident)."""
+        self._fit_to_content()
+        QtCore.QTimer.singleShot(0, self._fit_to_content)
 
     def _update_live_values(self, data, ias_ref=None):
         def fmt(v, conv=1.0, unit="", nd=0):
@@ -528,7 +563,7 @@ class TrimCalibrationDialog(QDialog):
         self.lbl_note.setText("\n".join(notes))
         self.btn_apply.setEnabled(True)
         self.btn_save.setEnabled(True)
-        self._fit_to_content()
+        self._refit()
 
     def _clear_result_labels(self):
         self.lbl_virtual.setText("Recommended Y Trim Gain (Virtual): <b>—</b>")
@@ -552,12 +587,17 @@ class TrimCalibrationDialog(QDialog):
         self._set_light(color, text)
 
     def _set_running(self, running):
+        banner_appearing = running and not self.banner.isVisible()
         self.banner.setVisible(running)
         self.btn_stop.setEnabled(running)
         self.btn_start.setEnabled(not running and self.btn_start.isEnabled())
         if running:
             self.btn_apply.setEnabled(False)
             self.btn_save.setEnabled(False)
+        if banner_appearing:
+            # The banner adds a row mid-flight; grow the window for it or the
+            # squeeze overlaps the curve's axis labels with the text below.
+            self._refit()
 
     def _refresh_idle(self):
         self.lbl_ias.setText("—")

--- a/telemffb/TrimCalibrationDialog.py
+++ b/telemffb/TrimCalibrationDialog.py
@@ -150,17 +150,29 @@ class TrimCalibrationDialog(QDialog):
         self.chk_trace = None
         if self._debug:
             debug_row = QHBoxLayout()
-            debug_row.addWidget(QLabel("Trim write method:"))
+            lbl_trim_method = InfoLabel(
+                text="Trim write method:",
+                tooltip=(
+                    "Debug options — this row is only visible when the Debug Mode "
+                    "system setting is enabled.\n\n"
+                    "Trim write method: how calibration commands the sim's elevator "
+                    "trim (MSFS).\n"
+                    "• Direct (default) — writes the ELEVATOR TRIM POSITION SimVar "
+                    "itself; the most reliable method across tested aircraft.\n"
+                    "• Axis event — sends AXIS_ELEV_TRIM_SET instead, which assumes "
+                    "the aircraft maps the event 1:1 onto its trim. Some addons "
+                    "mishandle the event (e.g. Just Flight); use this only to test "
+                    "an aircraft that misbehaves with the direct method.\n\n"
+                    "Record diagnostic trace: writes a per-frame CSV of everything "
+                    "the calibration commands and observes (trimcal_trace_*.csv in "
+                    "the TelemFFB log folder) — attach it when reporting a problem "
+                    "aircraft."))
+            debug_row.addWidget(lbl_trim_method)
             self.cmb_trim_method = QComboBox()
             self.cmb_trim_method.addItems([
                 "Direct (ELEVATOR TRIM POSITION)",
                 "Axis event (AXIS_ELEV_TRIM_SET)",
             ])
-            self.cmb_trim_method.setToolTip(
-                "How calibration commands the sim's elevator trim (MSFS).\n"
-                "Direct writes the trim SimVar itself and is the reliable default.\n"
-                "The axis event assumes the aircraft maps it 1:1 onto the trim —\n"
-                "some addons mishandle it (Just Flight). Debug option.")
             debug_row.addWidget(self.cmb_trim_method)
             self.chk_trace = QCheckBox("Record diagnostic trace")
             self.chk_trace.setChecked(False)

--- a/telemffb/TrimCalibrationDialog.py
+++ b/telemffb/TrimCalibrationDialog.py
@@ -479,7 +479,9 @@ class TrimCalibrationDialog(QDialog):
     def _show_result(self, result):
         self._result_shown = True
         self._last_result = result
-        self.curve.set_result(result["samples"], result["slope"], result["intercept"])
+        self.curve.set_result(
+            result["samples"], result["slope"], result["intercept"],
+            flagged=[f["index"] for f in result.get("flagged") or []])
         self.curve.set_live_point(None, None)
         current = result.get("current_virtual_y")
         current_txt = f"  &nbsp;·  current profile value: {current:.3f}" if current is not None else ""
@@ -503,6 +505,17 @@ class TrimCalibrationDialog(QDialog):
                 "the measurement. The result may still be fine — test it with Apply, and if "
                 "trim following seems off, consider re-running with a steadier airspeed "
                 "(stable power, and the airspeed-settle option enabled).")
+        flagged = result.get("flagged") or []
+        if flagged:
+            worst = max(abs(f["vs_fpm"]) for f in flagged)
+            where = ", ".join(f"{100 * f['trim']:+.0f}%" for f in flagged)
+            plural = "s" if len(flagged) > 1 else ""
+            notes.append(
+                f"{len(flagged)} station{plural} (trim {where}, shown in amber) sampled "
+                f"with a residual climb/descent of up to {worst:.0f} fpm — usually slow "
+                "airspeed drift. The curve may be slightly skewed near those points; if "
+                "trim following seems off there, consider re-running with a steadier "
+                "airspeed (stable power, airspeed-settle option enabled).")
         split = result.get("split")
         if split and split["mismatch"] > 0.2:
             notes.append(

--- a/telemffb/TrimCalibrationDialog.py
+++ b/telemffb/TrimCalibrationDialog.py
@@ -140,6 +140,38 @@ class TrimCalibrationDialog(QDialog):
         response_row.addStretch(1)
         root.addLayout(response_row)
 
+        # Debug-only controls (system settings 'debug' flag): trim write
+        # method override + per-run diagnostic trace, for problem-aircraft
+        # reports. Direct SimVar writes are the tested-primary method; the
+        # axis event stays selectable in case an aircraft ever requires it.
+        self._debug = bool(getattr(G, "system_settings", None)
+                           and G.system_settings.get("debug", False))
+        self.cmb_trim_method = None
+        self.chk_trace = None
+        if self._debug:
+            debug_row = QHBoxLayout()
+            debug_row.addWidget(QLabel("Trim write method:"))
+            self.cmb_trim_method = QComboBox()
+            self.cmb_trim_method.addItems([
+                "Direct (ELEVATOR TRIM POSITION)",
+                "Axis event (AXIS_ELEV_TRIM_SET)",
+            ])
+            self.cmb_trim_method.setToolTip(
+                "How calibration commands the sim's elevator trim (MSFS).\n"
+                "Direct writes the trim SimVar itself and is the reliable default.\n"
+                "The axis event assumes the aircraft maps it 1:1 onto the trim —\n"
+                "some addons mishandle it (Just Flight). Debug option.")
+            debug_row.addWidget(self.cmb_trim_method)
+            self.chk_trace = QCheckBox("Record diagnostic trace")
+            self.chk_trace.setChecked(False)
+            self.chk_trace.setToolTip(
+                "Write a per-frame CSV of everything the calibration commands and\n"
+                "observes to the TelemFFB log folder (trimcal_trace_*.csv).\n"
+                "Attach it when reporting a problem aircraft.")
+            debug_row.addWidget(self.chk_trace)
+            debug_row.addStretch(1)
+            root.addLayout(debug_row)
+
         # Warning banner shown only while the engine is flying the aircraft.
         self.banner = QLabel("⚠  TelemFFB is controlling your aircraft — stay ready to take over")
         self.banner.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -453,6 +485,13 @@ class TrimCalibrationDialog(QDialog):
         cal.settle_before_sweep = self.chk_settle.isChecked()
         cal.initial_gain_scale = {0: 1.0, 1: 0.5, 2: 0.25}.get(
             self.cmb_response.currentIndex(), 1.0)
+        if self._debug:
+            cal.trim_write_method = \
+                "axis" if self.cmb_trim_method.currentIndex() == 1 else "direct"
+            cal.trace_enabled = self.chk_trace.isChecked()
+        else:
+            cal.trim_write_method = "direct"
+            cal.trace_enabled = False
         cal.start()
 
     def _on_stop(self):

--- a/telemffb/custom_widgets.py
+++ b/telemffb/custom_widgets.py
@@ -2630,6 +2630,7 @@ class TrimCurveWidget(CurveWidget):
         self.y_max = 100.0
 
         self.sample_points = []          # [QPointF(trim%, elevator%)]
+        self.flagged_indices = set()     # sample indices taken with a VS residual
         self.fit_line = None             # (QPointF, QPointF) in %-space
         self.curve_polyline = []         # sorted samples joined = the calibrated curve
         self.extrap_tails = []           # dashed edge-slope segments beyond the band
@@ -2638,14 +2639,16 @@ class TrimCurveWidget(CurveWidget):
 
     # ---- data API -----------------------------------------------------------
 
-    def set_result(self, samples, slope, intercept):
+    def set_result(self, samples, slope, intercept, flagged=None):
         """Populate from calibration output.
 
         Args:
             samples: list of (trim_frac, u_elev_frac), both normalized [-1, 1].
             slope, intercept: linear fit of u_elev vs trim (normalized units).
+            flagged: sample indices accepted with a VS residual (drawn amber).
         """
         self.sample_points = [QPointF(t * 100.0, u * 100.0) for t, u in samples]
+        self.flagged_indices = set(flagged or [])
         xs = [p.x() for p in self.sample_points]
         ys = [p.y() for p in self.sample_points]
         if not xs:
@@ -2702,6 +2705,7 @@ class TrimCurveWidget(CurveWidget):
 
     def clear(self):
         self.sample_points = []
+        self.flagged_indices = set()
         self.fit_line = None
         self.curve_polyline = []
         self.extrap_tails = []
@@ -2805,10 +2809,15 @@ class TrimCurveWidget(CurveWidget):
                 painter.drawLine(self.map_to_widget_space(seg[0]),
                                  self.map_to_widget_space(seg[1]))
 
-        painter.setPen(QPen(self.axis_color, 1))
-        painter.setBrush(self.point_fill)
-        for p in self.sample_points:
+        for i, p in enumerate(self.sample_points):
             wp = self.map_to_widget_space(p)
+            if i in self.flagged_indices:
+                # taken with a residual VS (deadline compromise) — draw amber
+                painter.setPen(QPen(QColor("#8a6510"), 1))
+                painter.setBrush(QColor("#e6a817"))
+            else:
+                painter.setPen(QPen(self.axis_color, 1))
+                painter.setBrush(self.point_fill)
             painter.drawEllipse(QRectF(wp.x() - 3, wp.y() - 3, 6, 6))
 
         if self.live_point is not None:

--- a/telemffb/globals.py
+++ b/telemffb/globals.py
@@ -151,6 +151,13 @@ sim_listeners : 'SimListenerManager'
 # Triggers and flags
 force_reload_aircraft_trigger: bool = False
 
+trimcal_hold_until: float = 0.0
+"""While a trim calibration run owns the sim's elevator trim, trimwheel
+instances must not write their wheel position (two absolute writers fight
+frame-by-frame). The master broadcasts a refreshing hold over IPC; this is
+the local time.perf_counter() deadline, so a dead master un-mutes the wheel
+on its own within the TTL."""
+
 # Exception tracking
 exception_tracker : 'ExceptionTracker'  
 """Tracks logged exceptions for user notification and reporting"""

--- a/telemffb/sim/msfs_xp/MsfsXpTrimwheelMixIn.py
+++ b/telemffb/sim/msfs_xp/MsfsXpTrimwheelMixIn.py
@@ -32,6 +32,8 @@ class MsfsXpTrimwheelMixIn(MsfsXpFlightControlsMixIn):
         self.trim_active = False
         self._tw_limits_warned = False
         self._tw_hold_prev = False
+        self._tw_hold_pos = None       # wheel position parked during a calibration hold
+        self._tw_resync_tol = 0.003    # trim_active release tolerance (widened post-hold)
 
     # NOTE: no on_telemetry hook here. Trimwheel devices are single-purpose:
     # Aircraft.on_telemetry gates them BEFORE the cooperative effects chain
@@ -87,14 +89,22 @@ class MsfsXpTrimwheelMixIn(MsfsXpFlightControlsMixIn):
         phys_x, phys_y = self._get_device_axes()
         self._spring_handle.name = "trimwheel_ap_spring"
 
-        # A running trim calibration owns the sim's trim: keep the spring
-        # following (the motorized wheel then tracks the sweep) but hold all
-        # writes back to the sim, or two absolute writers fight every frame.
+        # A running trim calibration owns the sim's trim: hold all writes back
+        # to the sim (two absolute writers fight every frame) and PARK the
+        # wheel where it sits. Following the sweep would be pointless motion —
+        # the calibrator restores the starting trim at the end, so the parked
+        # position is already the correct post-run position; chasing the sweep
+        # only risks ending displaced and wedging the re-sync latch.
         hold = time.perf_counter() < G.trimcal_hold_until
+        if hold and not self._tw_hold_prev:
+            self._tw_hold_pos = phys_y
         if self._tw_hold_prev and not hold:
             # Calibration released the trim: reuse the button-trim latch so no
-            # position is sent until the wheel converges on the restored trim.
+            # position is sent until the wheel matches the restored trim. The
+            # restored trim ≈ the parked position, so this clears right away;
+            # the widened tolerance covers restore/readback imprecision.
             self.trim_active = True
+            self._tw_resync_tol = 0.02
         self._tw_hold_prev = hold
 
         # Sim-reported trim in normalized wheel space: direct mode maps
@@ -138,9 +148,14 @@ class MsfsXpTrimwheelMixIn(MsfsXpFlightControlsMixIn):
         if ap_active == 0:
 
             # trimwheel_pos = self.dampener.dampen_value(trimwheel_pos, '_elev_trim', derivative_hz=5, derivative_k=0.15)
-            self.cpO_y = round(utils.scale(trimwheel_pos, (-1, 1), (-4096, 4096)))
-            telem_data._tw_cpO_y = trimwheel_pos
-            self.spring_y.set_offset(trimwheel_pos)
+            # Parked at the hold-onset position during a calibration hold;
+            # normal sim-trim follow otherwise.
+            spring_pos = trimwheel_pos
+            if hold and self._tw_hold_pos is not None:
+                spring_pos = self._tw_hold_pos
+            self.cpO_y = round(utils.scale(spring_pos, (-1, 1), (-4096, 4096)))
+            telem_data._tw_cpO_y = spring_pos
+            self.spring_y.set_offset(spring_pos)
 
             # self.damper.damper(coef_y=0).start()
             self.spring_y.set_coefficient(self.trimwheel_ap_spring_gain, True)
@@ -183,8 +198,9 @@ class MsfsXpTrimwheelMixIn(MsfsXpFlightControlsMixIn):
                 # utils.dbprint('yellow', f"delta: {delta}")
                 telem_data.TRIM_DELTA = delta
                 if self.trim_active:
-                    if abs(delta) <= 0.003:
+                    if abs(delta) <= self._tw_resync_tol:
                         self.trim_active = False
+                        self._tw_resync_tol = 0.003   # back to the button-trim default
 
                 if not self.trim_active and not hold:
                     if self.trimwheel_use_axis:
@@ -192,12 +208,14 @@ class MsfsXpTrimwheelMixIn(MsfsXpFlightControlsMixIn):
                             pos_y_pos = -pos_y_pos
                             phys_y = -phys_y
                         self._simconnect.send_event_to_msfs(y_var, pos_y_pos)
+                        # print("TRIM POSITION", pos_y_pos)
                     elif trim_limits is not None:
                         # Direct mode: map the wheel through the trim travel
                         # and write the surface position itself (deg -> rad).
                         pos_y_pos = utils.scale(phys_y, (-1, 1), trim_limits)
                         pos_y_pos = pos_y_pos * 0.01745
                         self._simconnect.set_simdatum_to_msfs("ELEVATOR TRIM POSITION", pos_y_pos, units="radians")
+                        # print("TRIM TRIM POSITION", pos_y_pos)
                 self.last_pos_y_pos = pos_y_pos
                 telem_data._tw_last = self.last_pos_y_pos
 

--- a/telemffb/sim/msfs_xp/MsfsXpTrimwheelMixIn.py
+++ b/telemffb/sim/msfs_xp/MsfsXpTrimwheelMixIn.py
@@ -27,6 +27,7 @@ class MsfsXpTrimwheelMixIn(MsfsXpFlightControlsMixIn):
         self.last_trimwheel_y = None
         self.last_pos_y_pos = 0.0
         self.trim_active = False
+        self._tw_limits_warned = False
 
     # NOTE: no on_telemetry hook here. Trimwheel devices are single-purpose:
     # Aircraft.on_telemetry gates them BEFORE the cooperative effects chain
@@ -34,20 +35,28 @@ class MsfsXpTrimwheelMixIn(MsfsXpFlightControlsMixIn):
     # through the wheel.
 
     def msfs_update_trimwheel(self, telem_data: BaseTelemetryData):
-        """Drive trimwheel spring position from sim elevator trim and send axis to sim.
+        """Drive trimwheel spring position from sim elevator trim and send trim to the sim.
+
+        Two write methods, selected per aircraft via ``trimwheel_use_axis``:
+          - Direct (default, ``False``): write the ELEVATOR TRIM POSITION
+            SimVar itself, mapping the wheel through the aircraft's trim
+            travel limits. Works on most aircraft.
+          - Axis (``True``): send the AXIS_ELEV_TRIM_SET key event (or the
+            custom Y-axis variable when configured). Needed by aircraft whose
+            systems ignore direct surface writes (see per-model overrides in
+            defaults.xml, e.g. C208B, DA40, DA42).
 
         Telemetry:
             Read (MSFS):   APMaster       - Union[bool, int] (0 or 1); autopilot engaged state
             Read (XPLANE): APServos       - Union[bool, int] (0 or 1); autopilot servo state
-            Read: ElevTrim         - float (degrees); raw elevator trim angle; non-axis mode only
+            Read: ElevTrim         - float (degrees); raw elevator trim angle; direct mode only
                   ElevTrimMax      - float (degrees); upper trim travel limit; primary source
                   ElevTrimUpLmt    - float (degrees); fallback upper trim limit
                   ElevTrimMin      - float (degrees); lower trim travel limit; primary source
                   ElevTrimDnLmt    - float (degrees); fallback lower trim limit
-                  ElevTrimNeutral  - float (degrees); neutral trim position; NOT USED in any
-                                     active code path (non-axis path always raises ValueError)
                   ElevTrimPct      - float (–1.0 to 1.0); normalized elevator trim pct;
-                                     used in axis mode and for spring initialization
+                                     axis mode, spring initialization, and direct-mode
+                                     fallback when no usable limits are reported
             Written: trimwheel_pos_calc (float, –1.0 to 1.0; scaled trimwheel position)
                      phys_y             (float, –1.0 to 1.0; raw physical Y axis position)
                      _tw_cpO_y          (float; spring center offset, normalized)
@@ -56,9 +65,6 @@ class MsfsXpTrimwheelMixIn(MsfsXpFlightControlsMixIn):
                      _tw_pos_y_pos      (int or float; scaled position sent to MSFS)
                      TRIM_DELTA         (float; delta between physical and trim positions)
                      _tw_last           (int or float; last position sent to sim)
-
-        Note: ElevTrimNeutral is fetched but the non-axis code path is unreachable
-              (the else branch raises ValueError), so it is effectively unused.
         """
         if not self.is_trimwheel():
             return
@@ -76,29 +82,14 @@ class MsfsXpTrimwheelMixIn(MsfsXpFlightControlsMixIn):
         input_data = HapticEffect.device.get_input()
         phys_x, phys_y = self._get_device_axes()
         self._spring_handle.name = "trimwheel_ap_spring"
+
+        # Sim-reported trim in normalized wheel space: direct mode maps
+        # ElevTrim (degrees) through the travel limits, axis mode (or a
+        # limits-less direct mode) reads ElevTrimPct.
+        trim_limits = None if self.trimwheel_use_axis else self._trimwheel_trim_limits(telem_data)
+        trimwheel_pos = self._trimwheel_sim_pos(telem_data, trim_limits)
         if not self.trimwheel_use_axis:
-            trim_pos = telem_data.ElevTrim
-
-            trim_limit_max = telem_data.ElevTrimMax
-            if trim_limit_max == None:
-                trim_limit_max = telem_data.ElevTrimUpLmt
-
-            trim_limit_min = telem_data.ElevTrimMin
-            if trim_limit_min == None:
-                trim_limit_min = telem_data.ElevTrimDnLmt
-                # trim_limit_min = -trim_limit_max
-            trim_limit_neutral = telem_data.ElevTrimNeutral
-            # linear scale
-            trimwheel_pos = utils.scale(trim_pos, (trim_limit_min, trim_limit_max), (-1, 1))
-
-            #     if phys_y > 0:
-            #         trimwheel_pos = utils.scale(trim_pos, (trim_limit_neutral, trim_limit_up), (0, 1))
-            #     else:
-            #         trimwheel_pos = utils.scale(trim_pos, (-trim_limit_down, trim_limit_neutral), (-1, 0))
-
             telem_data.trimwheel_pos_calc = trimwheel_pos
-
-        # print(f"Linear:{round(phys_y, 4)}, Curved:{round(trimwheel_pos, 4)}")
 
         telem_data.phys_y = phys_y
         if not self.trimwheel_init:
@@ -129,11 +120,6 @@ class MsfsXpTrimwheelMixIn(MsfsXpFlightControlsMixIn):
                 #     self._simconnect.send_event_to_msfs(y_var, self.last_trimwheel_y)
                 return
         self.last_trimwheel_y = phys_y
-
-        if self.trimwheel_use_axis:
-            trimwheel_pos = telem_data.ElevTrimPct or 0
-        else:
-            raise ValueError("Trimwheel must use axis")
 
         if ap_active == 0:
 
@@ -192,14 +178,10 @@ class MsfsXpTrimwheelMixIn(MsfsXpFlightControlsMixIn):
                             pos_y_pos = -pos_y_pos
                             phys_y = -phys_y
                         self._simconnect.send_event_to_msfs(y_var, pos_y_pos)
-                    else:
-
-                        pos_y_pos = utils.scale(phys_y, (-1, 1), (trim_limit_min, trim_limit_max))
-                        #    if phys_y > 0:
-                        #        pos_y_pos = utils.scale(phys_y,(0, 1), (trim_limit_neutral, trim_limit_up))
-                        #    else:
-                        #        pos_y_pos = utils.scale(phys_y,(-1, 0), (-trim_limit_down, trim_limit_neutral))
-
+                    elif trim_limits is not None:
+                        # Direct mode: map the wheel through the trim travel
+                        # and write the surface position itself (deg -> rad).
+                        pos_y_pos = utils.scale(phys_y, (-1, 1), trim_limits)
                         pos_y_pos = pos_y_pos * 0.01745
                         self._simconnect.set_simdatum_to_msfs("ELEVATOR TRIM POSITION", pos_y_pos, units="radians")
                 self.last_pos_y_pos = pos_y_pos
@@ -213,3 +195,33 @@ class MsfsXpTrimwheelMixIn(MsfsXpFlightControlsMixIn):
 
             self._spring_handle.setCondition(self.spring_y)
             self._spring_handle.start(override=True)
+
+    def _trimwheel_trim_limits(self, telem_data: BaseTelemetryData):
+        """Elevator trim travel ``(min_deg, max_deg)`` for direct-mode writes.
+
+        MSFS 2024 reports ElevTrimMax/Min; 2020 only the Up/Dn limit vars, and
+        some aircraft omit the lower limit (assume symmetric travel). Returns
+        None (warning once) when no usable travel is reported — the caller then
+        falls back to the ElevTrimPct read-back and skips surface writes.
+        """
+        max_deg = telem_data.ElevTrimMax
+        if max_deg is None:
+            max_deg = telem_data.ElevTrimUpLmt
+        min_deg = telem_data.ElevTrimMin
+        if min_deg is None:
+            min_deg = telem_data.ElevTrimDnLmt
+        if min_deg is None and max_deg is not None:
+            min_deg = -max_deg
+        if max_deg is None or min_deg is None or max_deg == min_deg:
+            if not self._tw_limits_warned:
+                logging.warning("Trimwheel direct mode: no usable elevator trim limits in "
+                                "telemetry; using ElevTrimPct and skipping surface writes")
+                self._tw_limits_warned = True
+            return None
+        return (min_deg, max_deg)
+
+    def _trimwheel_sim_pos(self, telem_data: BaseTelemetryData, trim_limits):
+        """Normalized (–1..1) wheel position mirroring the sim's current trim."""
+        if trim_limits is not None and telem_data.ElevTrim is not None:
+            return utils.scale(telem_data.ElevTrim, trim_limits, (-1, 1))
+        return telem_data.ElevTrimPct or 0

--- a/telemffb/sim/msfs_xp/MsfsXpTrimwheelMixIn.py
+++ b/telemffb/sim/msfs_xp/MsfsXpTrimwheelMixIn.py
@@ -1,3 +1,6 @@
+import time
+
+import telemffb.globals as G
 import telemffb.utils as utils
 from telemffb.hw.ffb_rhino import HapticEffect
 from telemffb.sim.msfs_xp.MsfsXpFlightControlsMixIn import MsfsXpFlightControlsMixIn
@@ -28,6 +31,7 @@ class MsfsXpTrimwheelMixIn(MsfsXpFlightControlsMixIn):
         self.last_pos_y_pos = 0.0
         self.trim_active = False
         self._tw_limits_warned = False
+        self._tw_hold_prev = False
 
     # NOTE: no on_telemetry hook here. Trimwheel devices are single-purpose:
     # Aircraft.on_telemetry gates them BEFORE the cooperative effects chain
@@ -83,6 +87,16 @@ class MsfsXpTrimwheelMixIn(MsfsXpFlightControlsMixIn):
         phys_x, phys_y = self._get_device_axes()
         self._spring_handle.name = "trimwheel_ap_spring"
 
+        # A running trim calibration owns the sim's trim: keep the spring
+        # following (the motorized wheel then tracks the sweep) but hold all
+        # writes back to the sim, or two absolute writers fight every frame.
+        hold = time.perf_counter() < G.trimcal_hold_until
+        if self._tw_hold_prev and not hold:
+            # Calibration released the trim: reuse the button-trim latch so no
+            # position is sent until the wheel converges on the restored trim.
+            self.trim_active = True
+        self._tw_hold_prev = hold
+
         # Sim-reported trim in normalized wheel space: direct mode maps
         # ElevTrim (degrees) through the travel limits, axis mode (or a
         # limits-less direct mode) reads ElevTrimPct.
@@ -136,7 +150,7 @@ class MsfsXpTrimwheelMixIn(MsfsXpFlightControlsMixIn):
 
             if self._sim_is_xplane():  # unknown if this works
                 pos_y_pos = utils.scale(phys_y, (-1, 1), (1, 0))
-                if self.trimwheel_init:
+                if self.trimwheel_init and not hold:
                     self.send_xp_command(f"AXIS:cy={round(pos_y_pos, 5)}")
 
             if self._sim_is_msfs():
@@ -172,7 +186,7 @@ class MsfsXpTrimwheelMixIn(MsfsXpFlightControlsMixIn):
                     if abs(delta) <= 0.003:
                         self.trim_active = False
 
-                if not self.trim_active:
+                if not self.trim_active and not hold:
                     if self.trimwheel_use_axis:
                         if self.trimwheel_axis_invert:
                             pos_y_pos = -pos_y_pos

--- a/telemffb/sim/msfs_xp/TrimCalibrator.py
+++ b/telemffb/sim/msfs_xp/TrimCalibrator.py
@@ -58,6 +58,7 @@ import logging
 import math
 import time
 
+import telemffb.globals as G
 from telemffb.utils import PID, clamp, piecewise_linear
 
 logger = logging.getLogger(__name__)
@@ -240,6 +241,13 @@ class TrimCalibrator:
     HOLD_SPRING_COEFF = 1.0      # firm centered spring to keep hands-off stick put
     TRIM_AXIS_RANGE = 16383      # AXIS_ELEV_TRIM_SET: -16383..16384
 
+    # Trimwheel hold: a trimwheel instance writes its absolute wheel position
+    # to the sim every frame, which fights our trim commands writer-vs-writer.
+    # While the run is active we broadcast a self-expiring hold over IPC
+    # (refreshed well inside the TTL so a crashed master un-mutes the wheel).
+    TRIMWHEEL_HOLD_TTL_S = 3.0
+    TRIMWHEEL_HOLD_TX_S = 1.0    # refresh interval
+
     def __init__(self, aircraft):
         self.ac = aircraft
         self.state = CalState.IDLE
@@ -319,6 +327,7 @@ class TrimCalibrator:
         self._sign_cmd_accum = 0.0
         self._sign_rb_start = 0.0
         self._sign_flips = 0
+        self._hold_tx_t = 0.0            # last trimwheel-hold broadcast time
         self._u_sat_since = None
         # trim-neutralization state (discrete step-and-settle root-find)
         self._trim_touched = False       # any trim commanded this run (restore flag)
@@ -427,6 +436,10 @@ class TrimCalibrator:
             self.status_message = f"Aborted: {reason}"
             self.state = CalState.ABORT
             self._active = False
+            try:
+                self._set_trimwheel_hold(False)
+            except Exception:
+                pass  # the hold self-expires within the TTL anyway
 
     # ---- Per-frame driver (called from the telemetry thread) ----------------
 
@@ -449,6 +462,10 @@ class TrimCalibrator:
 
         if not self._precheck(telem_data):
             return
+
+        if now - self._hold_tx_t >= self.TRIMWHEEL_HOLD_TX_S:
+            self._hold_tx_t = now
+            self._set_trimwheel_hold(True)
 
         if not self._u_base_captured:
             self._capture_takeover_baseline(telem_data)
@@ -1411,5 +1428,23 @@ class TrimCalibrator:
                 self._set_trim(self._trim0)
         except Exception as e:
             logger.debug(f"trim restore skipped: {e}")
+        self._set_trimwheel_hold(False)
         self.state = end_state
         self._active = False
+
+    def _set_trimwheel_hold(self, active):
+        """Mute/unmute trimwheel instances' sim writes while we own the trim.
+
+        Sets the local deadline directly (covers a trimwheel on this instance)
+        and broadcasts to children over IPC. The hold self-expires after
+        TRIMWHEEL_HOLD_TTL_S without a refresh, and the trimwheel re-syncs its
+        wheel position before resuming writes (see MsfsXpTrimwheelMixIn).
+        """
+        G.trimcal_hold_until = \
+            (time.perf_counter() + self.TRIMWHEEL_HOLD_TTL_S) if active else 0.0
+        ipc = getattr(G, "ipc_instance", None)
+        if ipc is not None:
+            try:
+                ipc.send_broadcast_message(f"TRIMCAL HOLD:{1 if active else 0}")
+            except Exception as e:
+                logger.debug(f"trimwheel hold broadcast failed: {e}")

--- a/telemffb/sim/msfs_xp/TrimCalibrator.py
+++ b/telemffb/sim/msfs_xp/TrimCalibrator.py
@@ -63,6 +63,8 @@ from telemffb.utils import PID, clamp, piecewise_linear
 
 logger = logging.getLogger(__name__)
 
+MS_TO_FPM = 196.85
+
 
 class CalState(enum.Enum):
     IDLE = "idle"
@@ -201,7 +203,13 @@ class TrimCalibrator:
     # The instantaneous gate (STABLE_VS_TOL) is loose because real air jitters;
     # the mean gate rejects one-sided residuals from a still-converging PID,
     # which otherwise bias the recorded elevator in a trim-correlated way.
-    SAMPLE_VS_MEAN_TOL = 0.15    # m/s
+    SAMPLE_VS_MEAN_TOL = 0.15    # m/s (~30 fpm); clean-sample gate
+    SAMPLE_VS_HARD_TOL = 0.3048  # m/s (60 fpm); worse than this at the station
+                                 # deadline aborts — between the two, the best
+                                 # dwell is accepted and flagged in the results
+                                 # (a residual that holds steady is a finite-gain
+                                 # chase of a drifting target, usually airspeed —
+                                 # waiting longer cannot satisfy the clean gate)
 
     # Trim actuation. Commands are slew-rate limited — an instantaneous trim
     # step acts like yanking the stick and pitches the aircraft violently.
@@ -320,6 +328,8 @@ class TrimCalibrator:
         self._dwell_samples = []
         self._samples = []               # [(ElevTrimPct, u_elev)] steady-state points
         self._station_ias = []           # mean IAS per accepted station (drift diagnostics)
+        self._station_best = None        # best over-tolerance dwell at this station
+        self._flagged = []               # samples accepted with a VS residual (see result)
         # trim command state (read-back space; _set_trim maps to command space)
         self._trim_cmd = 0.0
         self._trim_sign = 1.0            # flipped at runtime if read-back moves opposite
@@ -904,6 +914,7 @@ class TrimCalibrator:
         self._step_settle_deadline = time.perf_counter() + ramp_time + self.STEP_SETTLE_TIMEOUT_S
         self._dwell_since = None
         self._dwell_samples = []
+        self._station_best = None
 
     def _next_station_target(self, last_u):
         """Pick the next station, expanding outward; None ends the sweep.
@@ -1025,45 +1036,99 @@ class TrimCalibrator:
             )
             if now - self._dwell_since >= self.STEP_DWELL_S:
                 n = len(self._dwell_samples)
+                mean_trim = sum(s[0] for s in self._dwell_samples) / n
+                mean_u = sum(s[1] for s in self._dwell_samples) / n
                 mean_vs = sum(s[2] for s in self._dwell_samples) / n
+                mean_ias = sum(s[3] for s in self._dwell_samples) / n
                 if abs(mean_vs) > self.SAMPLE_VS_MEAN_TOL:
                     # Still converging (one-sided VS residual): retry the dwell
-                    # rather than record a biased sample. The step deadline
-                    # still bounds the retries.
+                    # rather than record a biased sample, keeping the best
+                    # completed dwell for the deadline compromise below.
+                    if self._station_best is None or \
+                            abs(mean_vs) < abs(self._station_best[3]):
+                        self._station_best = (mean_trim, mean_u, mean_ias, mean_vs)
                     self._dwell_since = None
                     self._dwell_samples = []
                 else:
-                    mean_trim = sum(s[0] for s in self._dwell_samples) / n
-                    mean_u = sum(s[1] for s in self._dwell_samples) / n
-                    mean_ias = sum(s[3] for s in self._dwell_samples) / n
-                    self._samples.append((mean_trim, mean_u))
-                    self._station_ias.append(mean_ias)
-                    if self._side == 0:
-                        self._u_center = mean_u
-                    logger.info(
-                        f"Station {len(self._samples)} ({side_txt}): "
-                        f"trim {mean_trim:+.4f}, u_elev {mean_u:+.4f}, "
-                        f"IAS {mean_ias * 1.94384:.1f} kt"
-                    )
-                    self.progress = len(self._samples) / self.SWEEP_MAX_STATIONS
-                    nxt = self._next_station_target(mean_u)
-                    if nxt is None:
-                        if len(self._samples) >= self.MIN_SAMPLES_FOR_FIT:
-                            self._solve()
-                        else:
-                            self._abort("Trim band exhausted before enough samples "
-                                        "could be gathered")
-                        return
-                    self._begin_step(nxt)
+                    self._accept_station(mean_trim, mean_u, mean_ias)
+                    return
         else:
             self._dwell_since = None
             self._dwell_samples = []
 
         if now > self._step_settle_deadline:
-            self._abort(
-                f"Could not hold level at sweep station {len(self._samples) + 1} "
-                f"(VS {telem_data.VerticalSpeed * 196.85:+.0f} fpm)"
-            )
+            self._finish_station_on_deadline(telem_data, target)
+
+    def _accept_station(self, mean_trim, mean_u, mean_ias, residual_vs=None):
+        """Record a station sample and advance the sweep (or solve at the end).
+
+        ``residual_vs`` marks a deadline-compromise sample taken with a steady
+        VS residual; it is surfaced in the result so the user can judge it.
+        """
+        side_txt = "center" if self._side == 0 else \
+            ("nose-up side" if self._side > 0 else "nose-dn side")
+        self._samples.append((mean_trim, mean_u))
+        self._station_ias.append(mean_ias)
+        if self._side == 0:
+            self._u_center = mean_u
+        if residual_vs is not None:
+            self._flagged.append({
+                "index": len(self._samples) - 1,
+                "trim": mean_trim,
+                "vs_fpm": residual_vs * MS_TO_FPM,
+            })
+        logger.info(
+            f"Station {len(self._samples)} ({side_txt}): "
+            f"trim {mean_trim:+.4f}, u_elev {mean_u:+.4f}, "
+            f"IAS {mean_ias * 1.94384:.1f} kt"
+            + (f", residual VS {residual_vs * MS_TO_FPM:+.0f} fpm (flagged)"
+               if residual_vs is not None else "")
+        )
+        self.progress = len(self._samples) / self.SWEEP_MAX_STATIONS
+        nxt = self._next_station_target(mean_u)
+        if nxt is None:
+            if len(self._samples) >= self.MIN_SAMPLES_FOR_FIT:
+                self._solve()
+            else:
+                self._abort("Trim band exhausted before enough samples "
+                            "could be gathered")
+            return
+        self._begin_step(nxt)
+
+    def _finish_station_on_deadline(self, telem_data, target):
+        """Station deadline expired without a clean sample: compromise or abort.
+
+        A VS residual that holds steady across retries is the leveler chasing
+        a moving target at finite gain (usually slow airspeed drift), not a
+        lack of elevator authority — waiting longer cannot satisfy the clean
+        gate. Within SAMPLE_VS_HARD_TOL the best dwell is accepted and flagged
+        in the results; beyond it the run aborts, naming the gate that failed.
+        """
+        station = len(self._samples) + 1
+        if self._station_best is not None and \
+                abs(self._station_best[3]) <= self.SAMPLE_VS_HARD_TOL:
+            mean_trim, mean_u, mean_ias, mean_vs = self._station_best
+            logger.warning(
+                f"Station {station}: accepting best dwell with residual VS "
+                f"{mean_vs * MS_TO_FPM:+.0f} fpm (clean gate is "
+                f"{self.SAMPLE_VS_MEAN_TOL * MS_TO_FPM:.0f} fpm); flagged in results")
+            self._accept_station(mean_trim, mean_u, mean_ias, residual_vs=mean_vs)
+            return
+        rb_err = abs((telem_data.ElevTrimPct or 0) - target)
+        if rb_err > self.TRIM_STATION_TOL:
+            why = (f"trim read-back never reached the station target "
+                   f"(off by {100 * rb_err:.1f}%)")
+        elif abs(telem_data.Roll or 0) > self.STABLE_ROLL_TOL:
+            why = f"could not hold wings level (roll {telem_data.Roll:+.1f} deg)"
+        elif self._station_best is not None:
+            why = (f"VS residual would not settle below "
+                   f"{self.SAMPLE_VS_HARD_TOL * MS_TO_FPM:.0f} fpm (best "
+                   f"{self._station_best[3] * MS_TO_FPM:+.0f} fpm) — airspeed may "
+                   f"be drifting; try the airspeed-settle option or steadier power")
+        else:
+            why = (f"could not hold level "
+                   f"(VS {(telem_data.VerticalSpeed or 0) * MS_TO_FPM:+.0f} fpm)")
+        self._abort(f"Sweep station {station}: {why}")
 
     # ---- Phase: solve --------------------------------------------------------
 
@@ -1138,6 +1203,7 @@ class TrimCalibrator:
             "split": split,
             "curve": curve,
             "trim0": self._trim0,
+            "flagged": list(self._flagged),
         }
         self._done_status = (
             f"Done — Virtual Y = {virtual_y:.3f}"

--- a/telemffb/sim/msfs_xp/TrimCalibrator.py
+++ b/telemffb/sim/msfs_xp/TrimCalibrator.py
@@ -243,6 +243,10 @@ class TrimCalibrator:
     # polarity probe must begin from wings-level or its measurements start
     # contaminated (and any wrong prior feeds on the existing bank).
     START_MAX_ROLL_DEG = 10.0
+    # Pre-start VS gate: a probe begun in a real climb/descent measures the
+    # phugoid instead of its own input and can coin-flip the pitch polarity
+    # (field: back-to-back runs starting +1600 fpm after a previous abort).
+    START_MAX_VS = 2.54          # m/s (~500 fpm)
     IAS_BAND_FRAC = 0.30         # abort if IAS drifts more than ±30% from start
     TELEM_TIMEOUT_S = 1.0        # no telemetry for this long -> abort
 
@@ -396,6 +400,8 @@ class TrimCalibrator:
         if abs(telem_data.get("Pitch", 0)) > self.MAX_PITCH_DEG or \
                 abs(telem_data.get("Roll", 0)) > self.START_MAX_ROLL_DEG:
             return False, "Get roughly straight-and-level first"
+        if abs(telem_data.get("VerticalSpeed", 0)) > self.START_MAX_VS:
+            return False, "Level off first — still climbing/descending"
         return True, "Ready to calibrate"
 
     def start(self):
@@ -656,8 +662,16 @@ class TrimCalibrator:
         delta = (value - self._probe_ref) - self._probe_drift * elapsed
 
         # End the probe as soon as the response is unambiguous — holding the
-        # input for the full window just pumps energy into the aircraft.
-        if elapsed >= self.PROBE_TIME_S or abs(delta) >= exit_threshold:
+        # input for the full window just pumps energy into the aircraft. The
+        # early exit is only trusted once the ramp has fully applied the
+        # input: a threshold crossing in the first fraction of a second is
+        # residual aircraft motion (accelerating phugoid the linear drift
+        # model cannot capture), not probe response — and at a random phugoid
+        # phase the dPitch/dVS agreement is a coin flip, so a wrong-sign
+        # cascade then rails the elevator (seen in the field as full surface
+        # deflection during PROBE and a +/-15 deg attitude-guard abort).
+        if elapsed >= self.PROBE_TIME_S or \
+                (elapsed >= self.PROBE_RAMP_S and abs(delta) >= exit_threshold):
             if self._probe_stage == 0:
                 if abs(delta) >= self.PROBE_MIN_VS:
                     self._elev_sign = 1.0 if delta > 0 else -1.0
@@ -840,15 +854,50 @@ class TrimCalibrator:
                 self._neut_steps += 1
                 self._begin_neut_step(t + step)
         elif now > self._neut_deadline:
-            logger.warning("Trim neutralization step could not settle; sweeping around the "
-                           f"current point (steady elevator ~{self._neut_u_final:+.2f})")
-            self._finish_neutral(telem_data, centered=False)
+            self._neutral_give_up(telem_data, "Trim neutralization step could not settle")
             return
 
         if now - self._neut_start_t > self.NEUT_TIMEOUT_S:
-            logger.warning("Trim neutralization timed out; sweeping around the current point "
-                           f"(steady elevator ~{self._neut_u_final:+.2f})")
-            self._finish_neutral(telem_data, centered=False)
+            self._neutral_give_up(telem_data, "Trim neutralization timed out")
+
+    def _neutral_give_up(self, telem_data, what):
+        """Neutralization deadline/timeout: degrade or abort, honestly.
+
+        Sweeping around the current point is only a sane degradation when the
+        trim has DEMONSTRATED it responds (direction verified against the
+        read-back). Without that proof the sweep is doomed and proceeding just
+        defers the failure to a slow station timeout: commanded-but-deaf trim
+        aborts as unresponsive, and a give-up before any trim was even
+        commanded (first step settles in place; the aircraft would not calm
+        down) aborts naming the settle problem.
+        """
+        if not self._trim_dir_verified:
+            if abs(self._sign_cmd_accum) >= self.TRIM_SIGN_CHECK_DIST:
+                self._abort("Trim is not responding to commands")
+            else:
+                # Nothing was commanded yet, so name the gate that actually
+                # kept the settle from completing (the settle test is
+                # at-target AND VS AND roll — reporting VS for a trim-drift
+                # or roll problem sends the user chasing the wrong thing).
+                rb_err = abs((telem_data.ElevTrimPct or 0) - self._neut_target)
+                vs_fpm = (telem_data.VerticalSpeed or 0) * MS_TO_FPM
+                if rb_err > self.TRIM_STATION_TOL:
+                    why = (f"trim read-back drifted {100 * rb_err:.1f}% off the hold "
+                           "point while it was held steady — the aircraft's systems "
+                           "may be mishandling the trim commands or moving the trim "
+                           "themselves")
+                elif abs(telem_data.Roll or 0) > self.STABLE_ROLL_TOL:
+                    why = f"could not hold wings level (roll {telem_data.Roll:+.1f} deg)"
+                elif abs(telem_data.VerticalSpeed or 0) > self.STABLE_VS_TOL:
+                    why = f"could not settle level (VS {vs_fpm:+.0f} fpm)"
+                else:
+                    why = ("flight would not stay settled long enough to measure "
+                           f"(VS {vs_fpm:+.0f} fpm at abort)")
+                self._abort(f"Trim neutralization: {why}")
+            return
+        logger.warning(f"{what}; sweeping around the current point "
+                       f"(steady elevator ~{self._neut_u_final:+.2f})")
+        self._finish_neutral(telem_data, centered=False)
 
     def _finish_neutral(self, telem_data, centered):
         """Hand leveling back to the PID from a clean state and start the sweep.

--- a/telemffb/sim/msfs_xp/TrimCalibrator.py
+++ b/telemffb/sim/msfs_xp/TrimCalibrator.py
@@ -56,6 +56,7 @@ independent of the physical stick position.
 import enum
 import logging
 import math
+import os
 import time
 
 import telemffb.globals as G
@@ -260,6 +261,12 @@ class TrimCalibrator:
     TRIMWHEEL_HOLD_TTL_S = 3.0
     TRIMWHEEL_HOLD_TX_S = 1.0    # refresh interval
 
+    # Diagnostic flight recorder (armed via the trace_enabled run option in
+    # debug mode): one row per telemetry frame (commands, read-backs, loop
+    # internals), dumped as a CSV next to the logs at the end of the run.
+    # Cheap (tuples in a list) — and the only way to debug control-loop
+    # behavior precisely instead of from descriptions of moving graphs.
+
     def __init__(self, aircraft):
         self.ac = aircraft
         self.state = CalState.IDLE
@@ -274,6 +281,13 @@ class TrimCalibrator:
         # pre-derate the leveling loop for known-sensitive/pitchy aircraft
         # instead of waiting for the oscillation watchdog to discover it.
         self.initial_gain_scale = 1.0
+        # Run option: MSFS trim write method — "direct" (default) writes the
+        # ELEVATOR TRIM POSITION SimVar; "axis" sends AXIS_ELEV_TRIM_SET.
+        # Selectable only via the dialog's debug-mode pulldown (see _set_trim
+        # for why direct is primary).
+        self.trim_write_method = "direct"
+        # Run option: per-frame diagnostic CSV trace (debug-mode checkbox).
+        self.trace_enabled = False
         self.result = None          # dict on success, else None
         self.abort_reason = None
         # Set from the UI thread by stop(); consumed in the telemetry thread so
@@ -342,6 +356,14 @@ class TrimCalibrator:
         self._sign_rb_start = 0.0
         self._sign_flips = 0
         self._hold_tx_t = 0.0            # last trimwheel-hold broadcast time
+        self._trim_method_logged = False # effective write method logged once per run
+        # trace (diagnostic flight recorder) state
+        self._trace_rows = []
+        self._trace_t0 = None
+        self._trace_broken = False
+        self._trace_trim_write = None    # last raw value written to the sim's trim
+        self._trace_axis_y = None        # last elevator axis value sent to the sim
+        self._pitch_target_n = None      # cascade outer-loop demand (normalized deg)
         self._u_sat_since = None
         # trim-neutralization state (discrete step-and-settle root-find)
         self._trim_touched = False       # any trim commanded this run (restore flag)
@@ -456,6 +478,7 @@ class TrimCalibrator:
                 self._set_trimwheel_hold(False)
             except Exception:
                 pass  # the hold self-expires within the TTL anyway
+            self._dump_trace()
 
     # ---- Per-frame driver (called from the telemetry thread) ----------------
 
@@ -499,6 +522,84 @@ class TrimCalibrator:
         elif self.state == CalState.RESTORE:
             self._do_restore(telem_data, dt)
         # SOLVE/DONE/ABORT are terminal and handled inline when reached.
+
+        if self._active:
+            self._trace_frame(telem_data, now)
+
+    # ---- Diagnostic trace (per-run flight recorder) ---------------------------
+
+    TRACE_COLUMNS = ("t,state,detail,vs_ms,pitch_deg,roll_deg,ias_ms,"
+                     "trim_pct,trim_deg,trim_cmd,trim_target,trim_write,"
+                     "u_base_y,u_elev,u_ail,axis_y_sent,elev_defl_pct,"
+                     "pid_out,pid_i_term,"
+                     "pitch_target_n,gain_scale,pitch_mode,trim_sign,dir_verified")
+
+    def _log_trim_method(self, desc):
+        """Log the effective MSFS write method once per run (diagnostics)."""
+        if not self._trim_method_logged:
+            self._trim_method_logged = True
+            logger.info(f"Trim writes: {desc}")
+
+    def _trace_frame(self, telem_data, now):
+        """Record one row of everything the engine commanded and observed."""
+        if not self.trace_enabled or self._trace_broken:
+            return
+        try:
+            if self._trace_t0 is None:
+                self._trace_t0 = now
+            if self.state == CalState.PROBE:
+                detail, target = f"stage{self._probe_stage}-{self._probe_phase}", None
+            elif self.state == CalState.TRIM_NEUTRAL:
+                detail, target = f"step{self._neut_steps + 1}", self._neut_target
+            elif self.state == CalState.SWEEP:
+                detail, target = f"station{len(self._samples) + 1}", self._current_target
+            elif self.state == CalState.RESTORE:
+                detail, target = "", self._trim0
+            else:
+                detail, target = "", None
+            pid = self._pitch_pid
+            self._trace_rows.append((
+                now - self._trace_t0, self.state.name, detail,
+                telem_data.VerticalSpeed, telem_data.Pitch, telem_data.Roll,
+                telem_data.IAS, telem_data.ElevTrimPct, telem_data.ElevTrim,
+                self._trim_cmd, target, self._trace_trim_write,
+                self._u_base_y, self._u_elev, self._u_ail, self._trace_axis_y,
+                # actual surface position: vs u_elev it exposes aircraft that
+                # scale control input with airspeed (C208B: ~30% at cruise)
+                telem_data.ElevDeflPct,
+                pid.output, pid.ki * pid._integral, self._pitch_target_n,
+                self._gain_scale, self._pitch_mode, self._trim_sign,
+                int(self._trim_dir_verified),
+            ))
+        except Exception:
+            # Telemetry hot path: diagnostics must never break the run.
+            self._trace_broken = True
+            logger.exception("trace disabled for this run (frame capture failed)")
+
+    def _dump_trace(self):
+        rows, self._trace_rows = self._trace_rows, []
+        if not self.trace_enabled or not rows:
+            return
+        try:
+            folder = os.path.join(os.environ.get("LOCALAPPDATA", "."),
+                                  "VPForce-TelemFFB", "log")
+            os.makedirs(folder, exist_ok=True)
+            path = os.path.join(folder, time.strftime("trimcal_trace_%Y%m%d_%H%M%S.csv"))
+
+            def fmt(v):
+                if v is None:
+                    return ""
+                if isinstance(v, float):
+                    return f"{v:.5f}"
+                return str(v)
+
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(self.TRACE_COLUMNS + "\n")
+                for r in rows:
+                    f.write(",".join(fmt(v) for v in r) + "\n")
+            logger.info(f"Trim calibration trace: {len(rows)} frames -> {path}")
+        except Exception:
+            logger.exception("trace dump failed")
 
     # ---- Safety --------------------------------------------------------------
 
@@ -1345,8 +1446,10 @@ class TrimCalibrator:
             target_n = self._pitch_ref_n + clamp(
                 self.CASC_VS_TO_PITCH * (self.VS_TARGET - vs),
                 -self.CASC_MAX_TARGET_DEG, self.CASC_MAX_TARGET_DEG)
+            self._pitch_target_n = target_n
             return self._u_base_y + self._elev_sign * self._pitch_pid.update(target_n - pitch_n, dt)
 
+        self._pitch_target_n = None
         vs_err = self._elev_sign * (self.VS_TARGET - vs)
         return self._u_base_y + self._pitch_pid.update(vs_err, dt)
 
@@ -1468,15 +1571,17 @@ class TrimCalibrator:
 
         if self.ac._use_firmware_axis_backend():
             self.ac._send_firmware_fixed_axes(u_ail * x_scale, u_elev * y_scale)
+            self._trace_axis_y = round(u_elev * y_scale, 5)
         elif self.ac._sim_is_xplane():
             self.ac.send_xp_command(
                 f"AXIS:jx={round(u_ail * x_scale, 5)},jy={round(u_elev * y_scale, 5)}"
             )
+            self._trace_axis_y = round(u_elev * y_scale, 5)
         elif self.ac._sim_is_msfs():
             x_var, x_range = self.ac._get_msfs_axis_config('x', "AXIS_AILERONS_SET")
             y_var, y_range = self.ac._get_msfs_axis_config('y', "AXIS_ELEVATOR_SET")
             self.ac._send_msfs_axis_value(x_var, u_ail, x_range, x_scale)
-            self.ac._send_msfs_axis_value(y_var, u_elev, y_range, y_scale)
+            self._trace_axis_y = self.ac._send_msfs_axis_value(y_var, u_elev, y_range, y_scale)
 
         self._hold_stick_centered()
 
@@ -1504,18 +1609,50 @@ class TrimCalibrator:
     def _set_trim(self, pct):
         """Command the sim's elevator trim to an absolute normalized position.
 
-        ``pct`` is in ElevTrimPct read-back space. MSFS AXIS_* events are
-        sign-inverted relative to the SimVar read-backs (see the trimwheel
-        mixin's ``pos_y_pos = -int(pos_y_pos)``), hence the negation.
-        ``_trim_sign`` is a runtime correction on top of that, flipped by
-        :meth:`_advance_trim` for aircraft with inverted trim response
-        (cf. the ``trimwheel_axis_invert`` user setting).
+        ``pct`` is in ElevTrimPct read-back space.
+
+        MSFS — the DIRECT method (default) writes the ELEVATOR TRIM POSITION
+        SimVar, mapping pct per-side through the reported travel limits (like
+        the trimwheel's direct mode). Direct is self-referential — it writes
+        the read-back's own quantity — so a hold-in-place command is a true
+        no-op on any aircraft. The AXIS method (debug-mode selection, and the
+        fallback when no usable travel limits are reported) sends
+        AXIS_ELEV_TRIM_SET and assumes the sim maps the event value 1:1 onto
+        the read-back; field testing found aircraft that mishandle the event
+        (Just Flight Arrow III/IV and Hawk T1 apply it raw/32766 UNNEGATED,
+        relocating trim to -cmd/2 on every write — measured in
+        trimcal_trace_20260716_123259), which is why direct is primary. The
+        event value is sign-inverted relative to the SimVar read-backs (see
+        the trimwheel mixin's ``pos_y_pos = -int(pos_y_pos)``), hence the
+        negation. ``_trim_sign`` is a runtime correction on top of either
+        method, flipped by :meth:`_advance_trim` for aircraft with inverted
+        trim response (cf. the ``trimwheel_axis_invert`` user setting).
         """
         pct = clamp(pct * self._trim_sign, -1.0, 1.0)
         if self.ac._sim_is_msfs():
-            self.ac._simconnect.send_event_to_msfs(
-                "AXIS_ELEV_TRIM_SET", -int(pct * self.TRIM_AXIS_RANGE)
-            )
+            limits = None
+            if self.trim_write_method == "direct":
+                get_limits = getattr(self.ac, "_trimwheel_trim_limits", None)
+                telem = getattr(self.ac, "_telem_data", None)
+                if get_limits is not None and telem is not None:
+                    limits = get_limits(telem)
+            if limits is not None:
+                self._log_trim_method("direct ELEVATOR TRIM POSITION (travel "
+                                      f"{limits[0]:+.1f}..{limits[1]:+.1f} deg)")
+                dn, up = limits
+                deg = pct * up if pct >= 0 else pct * abs(dn)
+                self._trace_trim_write = round(deg, 4)
+                self.ac._simconnect.set_simdatum_to_msfs(
+                    "ELEVATOR TRIM POSITION", math.radians(deg), units="radians"
+                )
+                return
+            self._log_trim_method(
+                "AXIS_ELEV_TRIM_SET (debug selection)"
+                if self.trim_write_method == "axis"
+                else "AXIS_ELEV_TRIM_SET (no usable trim-limit telemetry for direct)")
+            out = -int(pct * self.TRIM_AXIS_RANGE)
+            self._trace_trim_write = out
+            self.ac._simconnect.send_event_to_msfs("AXIS_ELEV_TRIM_SET", out)
         elif self.ac._sim_is_xplane():
             # Write the pilot-control-level trim (float ratio -1..1); the FM
             # propagates it to sim/flightmodel2/controls/elevator_trim, which
@@ -1523,6 +1660,7 @@ class TrimCalibrator:
             # sign convention both ways, so no MSFS-style negation here.
             # Aircraft with custom trim systems that swallow this write are
             # caught by the read-back verification in _advance_trim.
+            self._trace_trim_write = round(pct, 5)
             self.ac.write_xp_dataref("sim/cockpit2/controls/elevator_trim", round(pct, 5), type="float")
 
     # ---- Teardown ------------------------------------------------------------
@@ -1546,6 +1684,7 @@ class TrimCalibrator:
         self._set_trimwheel_hold(False)
         self.state = end_state
         self._active = False
+        self._dump_trace()
 
     def _set_trimwheel_hold(self, active):
         """Mute/unmute trimwheel instances' sim writes while we own the trim.

--- a/telemffb/sim/msfs_xp/TrimCalibrator.py
+++ b/telemffb/sim/msfs_xp/TrimCalibrator.py
@@ -830,7 +830,7 @@ class TrimCalibrator:
         timeout the residual elevator becomes the new baseline instead (a
         constant, so it shifts only the fit's intercept, never the slope).
         """
-        self._u_base_y = 0.0 if centered else self._neut_u_f
+        self._u_base_y = 0.0 if centered else self._neut_u_final
         self._pitch_pid.reset()
         self._pitch_ref_n = None
         self._pitch_ref0 = None

--- a/telemffb/sim/msfs_xp/TrimCalibrator.py
+++ b/telemffb/sim/msfs_xp/TrimCalibrator.py
@@ -119,8 +119,13 @@ class TrimCalibrator:
 
     # Polarity probe.
     AUTO_DETECT_POLARITY = True
-    PROBE_U = 0.08               # normalized axis command applied during a probe
-    PROBE_TIME_S = 1.2           # per-axis probe window (upper bound)
+    PROBE_U = 0.08               # peak normalized probe command (before ramp/scale)
+    PROBE_U_MIN = 0.03           # floor so a control-response-derated probe still responds
+    PROBE_RAMP_S = 0.6           # ramp the probe in over this long instead of a step —
+                                 # a step is broadband and rings the phugoid on
+                                 # sensitive/pitchy aircraft, starting an oscillation
+                                 # that was not there; a ramp excites far less.
+    PROBE_TIME_S = 2.5           # per-axis probe window (upper bound; exits early on response)
     PROBE_BASELINE_S = 0.4       # no-input drift-measurement window before each probe
     PROBE_MIN_VS = 0.15          # m/s; min |dVS| to trust the elevator probe
     PROBE_MIN_ROLL = 1.0         # deg; min |dRoll| to trust the aileron probe
@@ -245,6 +250,10 @@ class TrimCalibrator:
         # SPEED_SETTLE_S after finding the natural trim point so the airspeed
         # stabilizes before the sweep. Users can disable it for a faster run.
         self.settle_before_sweep = True
+        # Run option: starting pitch-gain scale (1.0 = normal). Lets the user
+        # pre-derate the leveling loop for known-sensitive/pitchy aircraft
+        # instead of waiting for the oscillation watchdog to discover it.
+        self.initial_gain_scale = 1.0
         self.result = None          # dict on success, else None
         self.abort_reason = None
         # Set from the UI thread by stop(); consumed in the telemetry thread so
@@ -276,9 +285,10 @@ class TrimCalibrator:
         self._last_t = None
         self._phase_start_t = None
         self._probe_stage = 0            # 0 = elevator, 1 = aileron
-        self._probe_phase = "baseline"   # "baseline" (measure drift) then "probe"
+        self._probe_phase = "baseline"   # "baseline" -> "probe" -> "rampdown"
         self._probe_ref = None           # reference value at sub-phase start
         self._probe_drift = 0.0          # drift rate measured over the baseline window
+        self._probe_peak_u = 0.0         # probe magnitude at ramp-down start
         self._probe_pitch_ref = None     # pitch anchor for pitch-polarity detection
         self._probe_pitch_drift = 0.0
         # pitch loop mode: None until engaged (after the probe knows the
@@ -326,7 +336,7 @@ class TrimCalibrator:
         self._osc_dir = 0            # 0 = undetermined, +1 rising, -1 falling
         self._osc_prev_ext = None    # last confirmed extremum
         self._osc_amps = []          # recent half-cycle amplitudes (peak-to-peak / 2)
-        self._set_pitch_gain_scale(1.0)
+        self._set_pitch_gain_scale(clamp(self.initial_gain_scale, self.OSC_MIN_GAIN_SCALE, 1.0))
         # takeover smoothness: hold the stick where it rests and start the
         # axis output where the normal path left it (captured on first frame)
         self._hold_offs = None
@@ -556,12 +566,33 @@ class TrimCalibrator:
         elapsed = now - self._phase_start_t
         probe_on = self._probe_phase == "probe"
 
+        # Ramped, gentled probe command: ease the input in over PROBE_RAMP_S
+        # (no step) and scale by the control-response setting so sensitive
+        # aircraft get a smaller nudge. Enough to read polarity, not enough to
+        # start an oscillation. The ramp-DOWN is symmetric — releasing the
+        # input abruptly is as broadband a disturbance as an abrupt onset.
+        if probe_on:
+            mag = max(self.PROBE_U * self._gain_scale, self.PROBE_U_MIN)
+            u_probe = mag * min(elapsed / self.PROBE_RAMP_S, 1.0)
+        elif self._probe_phase == "rampdown":
+            u_probe = self._probe_peak_u * max(1.0 - elapsed / self.PROBE_RAMP_S, 0.0)
+        else:
+            u_probe = 0.0
+
         if self._probe_stage == 0:
             # Elevator probe. The aileron gets NO closed-loop help here: its
             # polarity is unverified at this point, and a wrong-sign
             # wings-level term is positive feedback — seen in the field as a
             # hard roll at start when beginning with residual bank.
-            self._u_elev = self._u_base_y + (self.PROBE_U if probe_on else 0.0)
+            if self._probe_phase == "rampdown":
+                # Blend the held elevator into the leveling loop as we release:
+                # recovery starts now (not one stage later) and the handoff is
+                # stepless. Pitch polarity was detected just before ramp-down.
+                r = min(elapsed / self.PROBE_RAMP_S, 1.0)
+                level_u = self._run_pitch_loop(telem_data, dt)
+                self._u_elev = (1.0 - r) * (self._u_base_y + self._probe_peak_u) + r * level_u
+            else:
+                self._u_elev = self._u_base_y + u_probe
             self._u_ail = self._u_base_x
             exit_threshold = self.PROBE_VS_EXIT
         else:
@@ -569,14 +600,14 @@ class TrimCalibrator:
             # polarities detected in stage 0 (a weak hold lets the probe's
             # climb build into a zoom that trips the attitude guard).
             self._u_elev = self._run_pitch_loop(telem_data, dt)
-            self._u_ail = self._u_base_x + (self.PROBE_U if probe_on else 0.0)
+            self._u_ail = self._u_base_x + u_probe
             exit_threshold = self.PROBE_ROLL_EXIT
 
         self._command_axes(telem_data)
 
         value = self._probe_value(telem_data)
 
-        if not probe_on:
+        if self._probe_phase == "baseline":
             if elapsed >= self.PROBE_BASELINE_S:
                 self._probe_drift = (value - self._probe_ref) / max(elapsed, 1e-6)
                 p_now = telem_data.Pitch or 0.0
@@ -585,6 +616,13 @@ class TrimCalibrator:
                 self._probe_phase = "probe"
                 self._phase_start_t = now
                 self._probe_ref = value
+            return
+
+        if self._probe_phase == "rampdown":
+            # Polarity is already recorded; just ease the input out, then
+            # advance to the next stage (or stabilize).
+            if elapsed >= self.PROBE_RAMP_S:
+                self._advance_probe_stage()
             return
 
         # Drift-compensated response to the probe input.
@@ -613,11 +651,6 @@ class TrimCalibrator:
                 else:
                     logger.warning(f"Elevator probe inconclusive (dVS={delta:+.2f} m/s); "
                                    f"keeping sign {self._elev_sign:+.0f}")
-                self._probe_stage = 1
-                self._phase_start_t = None
-                self._probe_ref = None
-                self._probe_drift = 0.0
-                self._pitch_mode = None  # (re-)engage the pitch loop with fresh polarity info
             else:
                 if abs(delta) >= self.PROBE_MIN_ROLL:
                     self._ail_sign = 1.0 if delta > 0 else -1.0
@@ -625,7 +658,26 @@ class TrimCalibrator:
                 else:
                     logger.warning(f"Aileron probe inconclusive (dRoll={delta:+.2f} deg); "
                                    f"keeping sign {self._ail_sign:+.0f}")
-                self._enter_stabilize()
+            # Polarity recorded; ease the input back out before advancing.
+            self._probe_peak_u = u_probe
+            self._probe_phase = "rampdown"
+            self._phase_start_t = now
+
+    def _advance_probe_stage(self):
+        """After a probe's ramp-down, move to the aileron probe or stabilize.
+
+        The pitch loop was engaged during the elevator ramp-down and stays
+        engaged (its integral already holds recovery progress); resetting it
+        here would discard that and re-step the elevator.
+        """
+        if self._probe_stage == 0:
+            self._probe_stage = 1
+            self._probe_phase = "baseline"
+            self._phase_start_t = None
+            self._probe_ref = None
+            self._probe_drift = 0.0
+        else:
+            self._enter_stabilize()
 
     # ---- Phase: stabilize ----------------------------------------------------
 

--- a/telemffb/telem/SimConnectManager.py
+++ b/telemffb/telem/SimConnectManager.py
@@ -352,6 +352,7 @@ class SimConnectManager(threading.Thread):
         SimVar("ElevDeflPct", "ELEVATOR DEFLECTION PCT", "Percent Over 100"),
         SimVar("ElevTrim", "ELEVATOR TRIM POSITION", "degrees"),
         SimVar("ElevTrimPct", "ELEVATOR TRIM PCT", "Percent Over 100"),
+        SimVar("ElevTrimPct_ex1", "ELEVATOR TRIM PCT EX1", "Percent Over 100", scale="(2 * x) - 1"),
         SimVar("ElevTrimDnLmt", "ELEVATOR TRIM DOWN LIMIT", "degrees"),
         SimVar("ElevTrimUpLmt", "ELEVATOR TRIM UP LIMIT", "degrees"),
         SimVar("ElevTrimNeutral", "ELEVATOR TRIM NEUTRAL", "degrees"),

--- a/tests/test_trim_calibrator.py
+++ b/tests/test_trim_calibrator.py
@@ -577,6 +577,32 @@ class TestTrimNeutralization:
         assert cal.result["trim0"] == pytest.approx(0.15, abs=0.05)
         assert cal.result["virtual_y"] == pytest.approx(1.5, abs=0.06)
 
+    def test_neutralization_timeout_sweeps_around_current_point(self, clock):
+        # Field crash: the give-up path (timeout / could-not-settle) referenced
+        # a misspelled attribute and raised AttributeError instead of falling
+        # back. Force the timeout and require a graceful hand-off: the residual
+        # steady elevator becomes the sweep baseline and the run still finishes.
+        ac = FakePlantAircraft(trim_natural=0.1)
+        ac.trim = 0.3
+        cal = TrimCalibrator(ac)
+        cal.start()
+        for _ in range(2000):
+            clock.advance(1 / 30.0)
+            cal.update(ac.telem())
+            ac.step(1 / 30.0)
+            if cal.state == CalState.TRIM_NEUTRAL:
+                break
+        assert cal.state == CalState.TRIM_NEUTRAL
+        cal._neut_start_t = time.perf_counter() - cal.NEUT_TIMEOUT_S - 1
+        clock.advance(1 / 30.0)
+        cal.update(ac.telem())
+        ac.step(1 / 30.0)
+        assert cal.state not in (CalState.TRIM_NEUTRAL, CalState.ABORT), \
+            "timeout must hand off to the sweep, not crash/abort"
+        assert cal._u_base_y == pytest.approx(cal._neut_u_final)
+        state = run_to_completion(cal, ac, clock)
+        assert state == CalState.DONE, f"ended in {state} ({cal.abort_reason})"
+
     def test_abort_during_neutralization_restores_entry_trim(self, clock):
         ac = FakePlantAircraft(trim_natural=0.1)
         ac.trim = 0.3

--- a/tests/test_trim_calibrator.py
+++ b/tests/test_trim_calibrator.py
@@ -9,10 +9,18 @@ import time
 
 import pytest
 
+import telemffb.globals as G
 from telemffb.sim.BaseTelemetryData import BaseTelemetryData
 from telemffb.sim.msfs_xp.TrimCalibrator import TrimCalibrator, CalState
 
 pytestmark = [pytest.mark.unit, pytest.mark.msfs, pytest.mark.joystick]
+
+
+@pytest.fixture(autouse=True)
+def _reset_trimwheel_hold():
+    """Runs set G.trimcal_hold_until (fake-clock timestamps); never leak it."""
+    yield
+    G.trimcal_hold_until = 0.0
 
 
 # --------------------------------------------------------------------------- #
@@ -69,6 +77,10 @@ class FakePlantAircraft:
         # Trim at which the elevator command needed to hold level is zero — the
         # aircraft's "natural" trim point the neutralization phase seeks.
         self.trim_natural = trim_natural
+
+        # trim response switches for corner-case tests
+        self.responds_to_axis = True   # False models an unresponsive trim
+        self.trim_response_sign = 1.0  # -1 models an inverted trim response
 
         # calibrator-read settings / flags
         self.joystick_trim_follow_gain_physical_y = physical_y
@@ -142,14 +154,17 @@ class FakePlantAircraft:
         # read-backs, so the "sim" negates the received value.
         return -data / 16383.0
 
+    def _apply_new_trim(self, new_trim):
+        new_trim *= self.trim_response_sign
+        self.max_trim_step = max(self.max_trim_step, abs(new_trim - self.trim))
+        self.trim = new_trim
+
     # --- plant integration ---
     def step(self, dt):
         # trim is applied by the "sim": the last commanded AXIS_ELEV_TRIM_SET.
         for event, data in self._simconnect.events:
-            if event == "AXIS_ELEV_TRIM_SET":
-                new_trim = self._apply_trim_event(data)
-                self.max_trim_step = max(self.max_trim_step, abs(new_trim - self.trim))
-                self.trim = new_trim
+            if event == "AXIS_ELEV_TRIM_SET" and self.responds_to_axis:
+                self._apply_new_trim(self._apply_trim_event(data))
         self._simconnect.events.clear()
 
         trim_eff = self.trim - self.trim_natural
@@ -303,15 +318,12 @@ class TestClosedLoop:
         assert cal.result["virtual_y"] == pytest.approx(1.8, abs=0.06)
 
     def test_inverted_trim_response_is_auto_corrected(self, clock):
-        # Some aircraft respond to AXIS_ELEV_TRIM_SET with the opposite sign
+        # Some aircraft respond to trim commands with the opposite sign
         # (cf. the trimwheel_axis_invert user setting). The engine must detect
         # the read-back moving against the command, flip its command sign, and
         # still produce the correct gain.
-        class InvertedTrimPlant(FakePlantAircraft):
-            def _apply_trim_event(self, data):
-                return data / 16383.0   # no negation: mirrored response
-
-        ac = InvertedTrimPlant(coupling=0.5, physical_y=1.0)
+        ac = FakePlantAircraft(coupling=0.5, physical_y=1.0)
+        ac.trim_response_sign = -1.0
         cal = TrimCalibrator(ac)
         cal.start()
         state = run_to_completion(cal, ac, clock)
@@ -351,16 +363,60 @@ class TestClosedLoop:
         assert split["mismatch"] > 0.2
 
     def test_unresponsive_trim_aborts(self, clock):
-        class DeafTrimPlant(FakePlantAircraft):
-            def _apply_trim_event(self, data):
-                return self.trim        # trim never moves
-
-        ac = DeafTrimPlant()
+        ac = FakePlantAircraft()
+        ac.responds_to_axis = False   # trim never moves
         cal = TrimCalibrator(ac)
         cal.start()
         state = run_to_completion(cal, ac, clock)
         assert state == CalState.ABORT
         assert "not responding" in cal.abort_reason
+
+
+# --------------------------------------------------------------------------- #
+#  Trimwheel hold (mute a trimwheel instance's sim writes during the run)
+# --------------------------------------------------------------------------- #
+
+class FakeIPC:
+    def __init__(self):
+        self.broadcasts = []
+
+    def send_broadcast_message(self, msg):
+        self.broadcasts.append(msg)
+
+
+class TestTrimwheelHold:
+    def test_hold_broadcast_lifecycle(self, clock):
+        # While the run owns the trim, a self-expiring hold must be set
+        # locally, broadcast to children, refreshed during the run, and
+        # released on completion.
+        ac = FakePlantAircraft()
+        cal = TrimCalibrator(ac)
+        ipc = FakeIPC()
+        G.ipc_instance = ipc
+        try:
+            cal.start()
+            clock.advance(1 / 30.0)
+            cal.update(ac.telem())
+            ac.step(1 / 30.0)
+            assert G.trimcal_hold_until > time.perf_counter(), "hold must be active"
+            assert ipc.broadcasts[0] == "TRIMCAL HOLD:1"
+            state = run_to_completion(cal, ac, clock)
+            assert state == CalState.DONE, f"ended in {state} ({cal.abort_reason})"
+            assert G.trimcal_hold_until == 0.0, "hold must be released on finish"
+            assert ipc.broadcasts[-1] == "TRIMCAL HOLD:0"
+            # refreshed ~1/s over a multi-second run, not sent just once
+            assert ipc.broadcasts.count("TRIMCAL HOLD:1") >= 3
+        finally:
+            del G.ipc_instance
+
+    def test_hold_released_on_abort(self, clock):
+        ac = FakePlantAircraft()
+        ac.responds_to_axis = False
+        cal = TrimCalibrator(ac)
+        cal.start()
+        state = run_to_completion(cal, ac, clock)
+        assert state == CalState.ABORT
+        assert G.trimcal_hold_until == 0.0, "hold must be released on abort"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_trim_calibrator.py
+++ b/tests/test_trim_calibrator.py
@@ -717,17 +717,18 @@ class TestTrimNeutralization:
         # a misspelled attribute and raised AttributeError instead of falling
         # back. Force the timeout and require a graceful hand-off: the residual
         # steady elevator becomes the sweep baseline and the run still finishes.
+        # (The hand-off requires the trim to have proven responsive first.)
         ac = FakePlantAircraft(trim_natural=0.1)
         ac.trim = 0.3
         cal = TrimCalibrator(ac)
         cal.start()
-        for _ in range(2000):
+        for _ in range(4000):
             clock.advance(1 / 30.0)
             cal.update(ac.telem())
             ac.step(1 / 30.0)
-            if cal.state == CalState.TRIM_NEUTRAL:
+            if cal.state == CalState.TRIM_NEUTRAL and cal._trim_dir_verified:
                 break
-        assert cal.state == CalState.TRIM_NEUTRAL
+        assert cal.state == CalState.TRIM_NEUTRAL and cal._trim_dir_verified
         cal._neut_start_t = time.perf_counter() - cal.NEUT_TIMEOUT_S - 1
         clock.advance(1 / 30.0)
         cal.update(ac.telem())
@@ -737,6 +738,76 @@ class TestTrimNeutralization:
         assert cal._u_base_y == pytest.approx(cal._neut_u_final)
         state = run_to_completion(cal, ac, clock)
         assert state == CalState.DONE, f"ended in {state} ({cal.abort_reason})"
+
+    def test_neutralization_giveup_with_deaf_trim_aborts(self, clock):
+        # Field failure: a give-up (step could not settle) proceeded to the
+        # sweep even though the trim had never responded — the sweep was
+        # doomed and only failed later, slowly. Unverified + commanded trim
+        # at give-up must abort as unresponsive.
+        ac = FakePlantAircraft()
+        cal = TrimCalibrator(ac)
+        cal.start()
+        for _ in range(2000):
+            clock.advance(1 / 30.0)
+            cal.update(ac.telem())
+            ac.step(1 / 30.0)
+            if cal.state == CalState.TRIM_NEUTRAL:
+                break
+        assert cal.state == CalState.TRIM_NEUTRAL
+        cal._trim_dir_verified = False
+        cal._sign_cmd_accum = cal.TRIM_SIGN_CHECK_DIST   # trim was commanded
+        cal._neut_deadline = time.perf_counter() - 1.0
+        clock.advance(1 / 30.0)
+        # unsettled frame (the deadline path only runs while not settled)
+        cal.update(ac.telem(VerticalSpeed=2.0))
+        assert cal.state == CalState.ABORT
+        assert "not responding" in cal.abort_reason
+
+    def test_neutralization_giveup_before_any_trim_command_aborts_with_settle_reason(self, clock):
+        # The first neutralization step settles in place (no trim commanded
+        # yet); if the aircraft never calms down, blaming the trim would be
+        # wrong — the abort must name the settle problem instead.
+        ac = FakePlantAircraft()
+        cal = TrimCalibrator(ac)
+        cal.start()
+        for _ in range(2000):
+            clock.advance(1 / 30.0)
+            cal.update(ac.telem())
+            ac.step(1 / 30.0)
+            if cal.state == CalState.TRIM_NEUTRAL:
+                break
+        assert cal.state == CalState.TRIM_NEUTRAL
+        cal._trim_dir_verified = False
+        cal._sign_cmd_accum = 0.0                        # nothing commanded yet
+        cal._neut_deadline = time.perf_counter() - 1.0
+        clock.advance(1 / 30.0)
+        # unsettled frame (the deadline path only runs while not settled)
+        cal.update(ac.telem(VerticalSpeed=2.0))
+        assert cal.state == CalState.ABORT
+        assert "could not settle level" in cal.abort_reason
+
+    def test_neutralization_giveup_names_uncommanded_trim_drift(self, clock):
+        # Field report: abort said VS -12 fpm — virtually level — because the
+        # message blamed VS regardless of the failing gate. When the trim
+        # read-back has wandered off the hold point on its own, say THAT.
+        ac = FakePlantAircraft()
+        cal = TrimCalibrator(ac)
+        cal.start()
+        for _ in range(2000):
+            clock.advance(1 / 30.0)
+            cal.update(ac.telem())
+            ac.step(1 / 30.0)
+            if cal.state == CalState.TRIM_NEUTRAL:
+                break
+        assert cal.state == CalState.TRIM_NEUTRAL
+        cal._trim_dir_verified = False
+        cal._sign_cmd_accum = 0.0
+        cal._neut_deadline = time.perf_counter() - 1.0
+        clock.advance(1 / 30.0)
+        # trim read-back far from the hold target, aircraft otherwise level
+        cal.update(ac.telem(ElevTrimPct=cal._neut_target + 0.1))
+        assert cal.state == CalState.ABORT
+        assert "drifted" in cal.abort_reason and "off the hold point" in cal.abort_reason
 
     def test_abort_during_neutralization_restores_entry_trim(self, clock):
         ac = FakePlantAircraft(trim_natural=0.1)
@@ -835,6 +906,41 @@ class TestPitchCascade:
         assert cal._pitch_mode == "cascade"
         assert cal._pitch_sign == -1.0
         assert cal.result["virtual_y"] == pytest.approx(0.5, abs=0.05)
+
+    def test_probe_early_exit_waits_for_ramp_completion(self, clock):
+        # Field failure: with the aircraft still surging from a previous
+        # aborted run, drift-compensated VS crossed the exit threshold in
+        # 0.15-0.22s — before the ramp had applied meaningful input — and the
+        # phugoid's dPitch/dVS phase coin-flipped the pitch polarity, railing
+        # the cascade. The early exit must not fire before PROBE_RAMP_S.
+        ac = FakePlantAircraft(K_E=80.0)   # strong response: exit threshold
+        cal = TrimCalibrator(ac)           # is reached well inside the ramp
+        cal.start()
+        probe_started_t = None
+        exit_elapsed = None
+        for _ in range(400):
+            clock.advance(1 / 30.0)
+            cal.update(ac.telem())
+            ac.step(1 / 30.0)
+            if cal.state != CalState.PROBE or cal._probe_stage != 0:
+                break
+            if cal._probe_phase == "probe" and probe_started_t is None:
+                probe_started_t = clock.t
+            if cal._probe_phase == "rampdown" and exit_elapsed is None:
+                exit_elapsed = clock.t - probe_started_t
+        assert exit_elapsed is not None, "elevator probe never concluded"
+        assert exit_elapsed >= cal.PROBE_RAMP_S - 1 / 30.0, \
+            f"probe exited {exit_elapsed:.2f}s in, before the ramp completed"
+        assert cal._elev_sign == 1.0
+
+    def test_can_start_rejects_climbing_aircraft(self, clock):
+        ac = FakePlantAircraft()
+        cal = TrimCalibrator(ac)
+        ok, msg = cal.can_start(ac.telem(VerticalSpeed=8.0))   # ~1600 fpm
+        assert not ok
+        assert "Level off" in msg
+        ok, _ = cal.can_start(ac.telem(VerticalSpeed=1.0))
+        assert ok
 
     def test_probe_input_is_ramped_not_stepped(self, clock):
         # An abrupt (step) probe rings the phugoid on sensitive aircraft; the

--- a/tests/test_trim_calibrator.py
+++ b/tests/test_trim_calibrator.py
@@ -420,6 +420,85 @@ class TestTrimwheelHold:
 
 
 # --------------------------------------------------------------------------- #
+#  Station-deadline compromise (residual VS: accept 30-60 fpm flagged, abort >60)
+# --------------------------------------------------------------------------- #
+
+class TestStationDeadlineCompromise:
+    def _run_to_sweep_with_samples(self, ac, cal, clock, min_samples=1):
+        cal.start()
+        for _ in range(40000):
+            clock.advance(1 / 30.0)
+            cal.update(ac.telem())
+            ac.step(1 / 30.0)
+            if cal.state == CalState.SWEEP and len(cal._samples) >= min_samples:
+                return
+        pytest.fail(f"never reached SWEEP with {min_samples} samples "
+                    f"({cal.state}, {cal.abort_reason})")
+
+    def test_residual_vs_in_band_is_accepted_and_flagged(self, clock):
+        # A steady 30-60 fpm residual is a finite-gain chase of a drifting
+        # target: at the station deadline the best dwell must be accepted,
+        # flagged in the result, and the run must still complete.
+        ac = FakePlantAircraft()
+        cal = TrimCalibrator(ac)
+        self._run_to_sweep_with_samples(ac, cal, clock)
+        n_before = len(cal._samples)
+        last_trim, last_u = cal._samples[-1]
+        cal._station_best = (last_trim + 0.03, last_u, 60.0, 0.22)   # ~+43 fpm
+        cal._step_settle_deadline = time.perf_counter() - 1.0
+        clock.advance(1 / 30.0)
+        cal.update(ac.telem())
+        ac.step(1 / 30.0)
+        assert cal.state != CalState.ABORT, f"aborted: {cal.abort_reason}"
+        assert len(cal._samples) == n_before + 1, "compromise sample must be recorded"
+        assert len(cal._flagged) == 1
+        assert cal._flagged[0]["index"] == n_before
+        assert cal._flagged[0]["vs_fpm"] == pytest.approx(0.22 * 196.85, abs=0.5)
+        state = run_to_completion(cal, ac, clock)
+        assert state == CalState.DONE, f"ended in {state} ({cal.abort_reason})"
+        assert cal.result["flagged"], "flag must surface in the result payload"
+
+    def test_residual_vs_above_hard_limit_aborts_with_reason(self, clock):
+        ac = FakePlantAircraft()
+        cal = TrimCalibrator(ac)
+        self._run_to_sweep_with_samples(ac, cal, clock)
+        # sit exactly on-station so the abort names the VS gate, not the trim ramp
+        cal._current_target = ac.trim
+        cal._trim_cmd = ac.trim
+        cal._station_best = (ac.trim, 0.0, 60.0, 0.45)   # ~+89 fpm
+        cal._step_settle_deadline = time.perf_counter() - 1.0
+        clock.advance(1 / 30.0)
+        cal.update(ac.telem())
+        ac.step(1 / 30.0)
+        assert cal.state == CalState.ABORT
+        assert "would not settle below 60 fpm" in cal.abort_reason
+        assert "+89 fpm" in cal.abort_reason
+
+    def test_station_deadline_names_unreached_trim_target(self, clock):
+        # The old message blamed VS regardless of the failing gate; a station
+        # whose trim read-back never arrived must say so.
+        ac = FakePlantAircraft()
+        cal = TrimCalibrator(ac)
+        self._run_to_sweep_with_samples(ac, cal, clock)
+        cal._current_target = ac.trim + 0.2   # far from the read-back
+        cal._station_best = None
+        cal._step_settle_deadline = time.perf_counter() - 1.0
+        clock.advance(1 / 30.0)
+        cal.update(ac.telem())
+        ac.step(1 / 30.0)
+        assert cal.state == CalState.ABORT
+        assert "never reached the station target" in cal.abort_reason
+
+    def test_clean_run_has_no_flags(self, clock):
+        ac = FakePlantAircraft()
+        cal = TrimCalibrator(ac)
+        cal.start()
+        state = run_to_completion(cal, ac, clock)
+        assert state == CalState.DONE
+        assert cal.result["flagged"] == []
+
+
+# --------------------------------------------------------------------------- #
 #  Safety / aborts
 # --------------------------------------------------------------------------- #
 

--- a/tests/test_trim_calibrator.py
+++ b/tests/test_trim_calibrator.py
@@ -497,12 +497,15 @@ class TestSafety:
         # must sit exactly on the takeover baseline (no step, no nudge yet).
         expected_base = 0.0 - 0.2 * 1.0 * (1 - 0.5)   # -0.10
         assert ac.cmd_elev == pytest.approx(expected_base, abs=1e-6)
-        # After the baseline window, the probe nudge rides on the baseline.
-        for _ in range(int(cal.PROBE_BASELINE_S * 30) + 2):
+        # Through the baseline window and into the probe, the command must
+        # never jump — it stays on the baseline, then the probe eases in.
+        prev = ac.cmd_elev
+        for _ in range(int(cal.PROBE_BASELINE_S * 30) + 4):
             clock.advance(1 / 30.0)
             cal.update(ac.telem())
             ac.step(1 / 30.0)
-        assert ac.cmd_elev == pytest.approx(expected_base + cal.PROBE_U, abs=1e-6)
+            assert abs(ac.cmd_elev - prev) < cal.PROBE_U * 0.3, "command stepped"
+            prev = ac.cmd_elev
 
     def test_abort_on_telemetry_gap(self, clock):
         ac, cal = self._armed(clock)
@@ -672,6 +675,51 @@ class TestPitchCascade:
         assert cal._pitch_sign == -1.0
         assert cal.result["virtual_y"] == pytest.approx(0.5, abs=0.05)
 
+    def test_probe_input_is_ramped_not_stepped(self, clock):
+        # An abrupt (step) probe rings the phugoid on sensitive aircraft; the
+        # probe must ease its input in over several frames, and still detect
+        # polarity.
+        ac = FakePlantAircraft()
+        cal = TrimCalibrator(ac)
+        cal.start()
+        prev = ac.cmd_elev
+        max_jump = 0.0
+        for _ in range(400):
+            clock.advance(1 / 30.0)
+            cal.update(ac.telem())
+            ac.step(1 / 30.0)
+            # Measure across BOTH the ramp-up and the ramp-down of the
+            # elevator probe: neither onset nor release may step.
+            if cal.state == CalState.PROBE and cal._probe_stage == 0 \
+                    and cal._probe_phase != "baseline":
+                max_jump = max(max_jump, abs(ac.cmd_elev - prev))
+            prev = ac.cmd_elev
+            if cal._probe_stage == 1 or cal.state != CalState.PROBE:
+                break
+        assert max_jump < cal.PROBE_U * 0.3, f"probe stepped ({max_jump:.3f}); should ramp"
+        assert cal._elev_sign == 1.0, "polarity must still be detected from the ramped probe"
+
+    def test_probe_magnitude_scales_with_control_response(self, clock):
+        # Minimal control response must gentle the probe too, not just the
+        # leveling loop — but never below the response floor.
+        ac = FakePlantAircraft()
+        cal = TrimCalibrator(ac)
+        cal.initial_gain_scale = 0.25
+        cal.start()
+        peak = 0.0
+        for _ in range(400):
+            clock.advance(1 / 30.0)
+            cal.update(ac.telem())
+            ac.step(1 / 30.0)
+            if cal.state == CalState.PROBE and cal._probe_stage == 0 \
+                    and cal._probe_phase == "probe":
+                peak = max(peak, abs(ac.cmd_elev))
+            if cal._probe_stage == 1 or cal.state != CalState.PROBE:
+                break
+        # 0.08 * 0.25 = 0.02, floored at PROBE_U_MIN (0.03); well under full 0.08
+        assert peak <= cal.PROBE_U * 0.6, f"derated probe too strong ({peak:.3f})"
+        assert peak >= cal.PROBE_U_MIN * 0.8, f"derated probe below floor ({peak:.3f})"
+
     def test_legacy_fallback_when_pitch_unresponsive(self, clock):
         # No usable pitch response (e.g. bad telemetry): polarity stays
         # unknown, so the safe legacy VS-only loop must fly the run.
@@ -736,6 +784,18 @@ class TestOscillationWatchdog:
         _feed_oscillation(cal, [0.9, 0.7, 0.55, 0.45, 0.4])   # decaying
         _feed_oscillation(cal, [0.1, 0.2, 0.3])               # below jitter floor
         assert cal._gain_scale == pytest.approx(1.0)
+
+    def test_initial_gain_scale_pre_derates_loop(self, clock):
+        # User-selected Control Response: start gentler for known-sensitive
+        # aircraft; the watchdog backs off from there if still needed.
+        ac = FakePlantAircraft()
+        cal = TrimCalibrator(ac)
+        cal.initial_gain_scale = 0.5
+        cal.start()
+        assert cal._gain_scale == pytest.approx(0.5)
+        assert cal._pitch_pid.kp == pytest.approx(cal.PITCH_KP * 0.5)
+        _feed_oscillation(cal, GROWING)
+        assert cal._gain_scale == pytest.approx(0.25)
 
     def test_backoff_preserves_integral_output_term(self, clock):
         # The integral carries the trim-holding output; backing off must not

--- a/tests/test_trim_calibrator.py
+++ b/tests/test_trim_calibrator.py
@@ -5,6 +5,7 @@ tests drive the calibrator against an in-test ``FakePlantAircraft`` — a minima
 implementation of the aircraft interface the calibrator uses, plus a first-order
 pitch/roll toy model — over a monkeypatched deterministic clock.
 """
+import math
 import time
 
 import pytest
@@ -17,8 +18,9 @@ pytestmark = [pytest.mark.unit, pytest.mark.msfs, pytest.mark.joystick]
 
 
 @pytest.fixture(autouse=True)
-def _reset_trimwheel_hold():
-    """Runs set G.trimcal_hold_until (fake-clock timestamps); never leak it."""
+def _calibrator_test_env():
+    """Never leak G.trimcal_hold_until (fake-clock timestamps). The diagnostic
+    trace defaults OFF on the engine, so no CSVs hit the real log folder."""
     yield
     G.trimcal_hold_until = 0.0
 
@@ -51,9 +53,13 @@ class FakeSpringHandle:
 class FakeSimConnect:
     def __init__(self):
         self.events = []
+        self.sim_data = []
 
     def send_event_to_msfs(self, event, data=0):
         self.events.append((event, data))
+
+    def set_simdatum_to_msfs(self, simvar, value, units=""):
+        self.sim_data.append((simvar, value, units))
 
 
 class FakePlantAircraft:
@@ -78,9 +84,17 @@ class FakePlantAircraft:
         # aircraft's "natural" trim point the neutralization phase seeks.
         self.trim_natural = trim_natural
 
-        # trim response switches for corner-case tests
-        self.responds_to_axis = True   # False models an unresponsive trim
+        # trim plumbing: travel limits enable the calibrator's direct SimVar
+        # method (the shipping default); switches model corner-case aircraft
+        self.report_limits = True
+        self.trim_up_limit = 15.0      # degrees
+        self.trim_dn_limit = -15.0     # degrees (signed, like the telemetry)
+        self.responds_to_simvar = True # False models trim deaf to direct writes
+        self.responds_to_axis = True   # False models trim deaf to axis events
         self.trim_response_sign = 1.0  # -1 models an inverted trim response
+        self.simvar_trim_writes = 0    # trim writes received (even if ignored)
+        self.axis_trim_events = 0
+        self._telem_data = None        # set per frame by telem(), like TelemManager
 
         # calibrator-read settings / flags
         self.joystick_trim_follow_gain_physical_y = physical_y
@@ -149,10 +163,22 @@ class FakePlantAircraft:
         """Trim->pitch coupling; override for nonlinear/kinked aircraft."""
         return self.coupling
 
+    def _trimwheel_trim_limits(self, telem_data):
+        # aircraft interface used by the calibrator's direct write method
+        if not self.report_limits:
+            return None
+        return (self.trim_dn_limit, self.trim_up_limit)
+
     def _apply_trim_event(self, data):
         # MSFS AXIS_* events are sign-inverted relative to the SimVar
         # read-backs, so the "sim" negates the received value.
         return -data / 16383.0
+
+    def _apply_trim_simvar(self, radians):
+        # ElevTrimPct read-back normalized per-side against the travel limits
+        # (mirror of the calibrator's direct-mode mapping)
+        deg = math.degrees(radians)
+        return deg / self.trim_up_limit if deg >= 0 else deg / abs(self.trim_dn_limit)
 
     def _apply_new_trim(self, new_trim):
         new_trim *= self.trim_response_sign
@@ -161,11 +187,20 @@ class FakePlantAircraft:
 
     # --- plant integration ---
     def step(self, dt):
-        # trim is applied by the "sim": the last commanded AXIS_ELEV_TRIM_SET.
+        # trim is applied by the "sim": the last commanded value on whichever
+        # write method this aircraft honors.
         for event, data in self._simconnect.events:
-            if event == "AXIS_ELEV_TRIM_SET" and self.responds_to_axis:
-                self._apply_new_trim(self._apply_trim_event(data))
+            if event == "AXIS_ELEV_TRIM_SET":
+                self.axis_trim_events += 1
+                if self.responds_to_axis:
+                    self._apply_new_trim(self._apply_trim_event(data))
         self._simconnect.events.clear()
+        for simvar, value, units in self._simconnect.sim_data:
+            if simvar == "ELEVATOR TRIM POSITION":
+                self.simvar_trim_writes += 1
+                if self.responds_to_simvar:
+                    self._apply_new_trim(self._apply_trim_simvar(value))
+        self._simconnect.sim_data.clear()
 
         trim_eff = self.trim - self.trim_natural
         target_vs = self.K_E * (self.cmd_elev + self.effective_coupling(trim_eff) * trim_eff)
@@ -187,7 +222,9 @@ class FakePlantAircraft:
             "APServos": 0,
         }
         data.update(over)
-        return BaseTelemetryData(initial=data)
+        telem = BaseTelemetryData(initial=data)
+        self._telem_data = telem   # TelemManager does this before on_telemetry
+        return telem
 
 
 # --------------------------------------------------------------------------- #
@@ -364,17 +401,78 @@ class TestClosedLoop:
 
     def test_unresponsive_trim_aborts(self, clock):
         ac = FakePlantAircraft()
-        ac.responds_to_axis = False   # trim never moves
+        ac.responds_to_simvar = False   # trim never moves
+        ac.responds_to_axis = False
         cal = TrimCalibrator(ac)
         cal.start()
         state = run_to_completion(cal, ac, clock)
         assert state == CalState.ABORT
         assert "not responding" in cal.abort_reason
 
+    def test_direct_simvar_write_is_the_default_method(self, clock):
+        # Field-tested primary: direct ELEVATOR TRIM POSITION writes succeed
+        # across the aircraft the axis event fails on (Just Flight mishandles
+        # the event value); the axis event remains a debug-mode selection.
+        ac = FakePlantAircraft(coupling=0.5, physical_y=1.0)
+        cal = TrimCalibrator(ac)
+        cal.start()
+        state = run_to_completion(cal, ac, clock)
+        assert state == CalState.DONE, f"ended in {state} ({cal.abort_reason})"
+        assert ac.simvar_trim_writes > 0
+        assert ac.axis_trim_events == 0, "axis event must not be used by default"
+        assert cal.result["virtual_y"] == pytest.approx(0.5, abs=0.05)
+
+    def test_axis_event_method_selectable(self, clock):
+        ac = FakePlantAircraft(coupling=0.5, physical_y=1.0)
+        cal = TrimCalibrator(ac)
+        cal.trim_write_method = "axis"
+        cal.start()
+        state = run_to_completion(cal, ac, clock)
+        assert state == CalState.DONE, f"ended in {state} ({cal.abort_reason})"
+        assert ac.axis_trim_events > 0
+        assert ac.simvar_trim_writes == 0
+        assert cal.result["virtual_y"] == pytest.approx(0.5, abs=0.05)
+
+    def test_direct_without_limits_falls_back_to_axis_event(self, clock):
+        # No usable travel limits in telemetry: direct cannot map pct to
+        # degrees, so the axis event carries the run.
+        ac = FakePlantAircraft(coupling=0.5, physical_y=1.0)
+        ac.report_limits = False
+        cal = TrimCalibrator(ac)
+        cal.start()
+        state = run_to_completion(cal, ac, clock)
+        assert state == CalState.DONE, f"ended in {state} ({cal.abort_reason})"
+        assert ac.simvar_trim_writes == 0
+        assert ac.axis_trim_events > 0
+        assert cal.result["virtual_y"] == pytest.approx(0.5, abs=0.05)
+
 
 # --------------------------------------------------------------------------- #
-#  Trimwheel hold (mute a trimwheel instance's sim writes during the run)
+#  Diagnostic trace
 # --------------------------------------------------------------------------- #
+
+class TestDiagnosticTrace:
+    def test_trace_records_frames_and_dumps_csv(self, clock, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+        ac = FakePlantAircraft()
+        cal = TrimCalibrator(ac)
+        cal.trace_enabled = True
+        cal.start()
+        state = run_to_completion(cal, ac, clock)
+        assert state == CalState.DONE
+        files = list((tmp_path / "VPForce-TelemFFB" / "log").glob("trimcal_trace_*.csv"))
+        assert len(files) == 1
+        lines = files[0].read_text().splitlines()
+        header = lines[0].split(",")
+        assert lines[0] == TrimCalibrator.TRACE_COLUMNS
+        assert len(lines) > 100, "a full run must record hundreds of frames"
+        # spot-check a data row: state column populated, floats parse
+        row = dict(zip(header, lines[1].split(",")))
+        assert row["state"] in ("PROBE", "STABILIZE")
+        float(row["vs_ms"])
+        float(row["u_elev"])
+        # rows are cleared after the dump (no growth across runs)
+        assert cal._trace_rows == []
 
 class FakeIPC:
     def __init__(self):
@@ -411,6 +509,7 @@ class TestTrimwheelHold:
 
     def test_hold_released_on_abort(self, clock):
         ac = FakePlantAircraft()
+        ac.responds_to_simvar = False
         ac.responds_to_axis = False
         cal = TrimCalibrator(ac)
         cal.start()

--- a/tests/test_trimwheel_effects_gate.py
+++ b/tests/test_trimwheel_effects_gate.py
@@ -1,0 +1,68 @@
+"""Trimwheel devices are single-purpose: no haptic effects may run on them.
+
+The mixin refactor lost the old per-class early-return guards, so the whole
+cooperative effects chain (engine rumble was the one noticed in the field)
+played through trimwheel devices. ``Aircraft.on_telemetry`` now gates
+trimwheels BEFORE the chain; these tests pin that gate with a positive
+control proving the negative assertion has teeth.
+"""
+import pytest
+
+from tests.framework.base import BaseTelemetryEffectTestCase
+from tests.framework.utils import TelemetryDataBuilder
+from telemffb.sim.msfs_xp.PropellerAircraft import PropellerAircraft
+
+pytestmark = [pytest.mark.unit, pytest.mark.msfs]
+
+
+def _telem(ffb_type):
+    return (TelemetryDataBuilder()
+            .ffb_type(ffb_type)
+            .set("N", "TestAircraft")
+            .set("Parked", 0)
+            .set("PropRPM", 2400.0)
+            .set("IAS", 60.0)
+            .set("AccBody", [0, 1, 0])
+            .set("VelWorld", [0.0, 0.0, 60.0])
+            .set("AmbWind", [0.0, 0.0, 0.0])
+            .set("Heading", 0.0)
+            .set("Pitch", 0.0)
+            .set("Roll", 0.0)
+            .build())
+
+
+class TestTrimwheelEffectsGate(BaseTelemetryEffectTestCase):
+    def _aircraft(self):
+        ac = self.create_aircraft_instance(PropellerAircraft, _test_sim_is_msfs=True)
+        ac._sim_is = lambda sim: sim == "MSFS"   # rumble uses _sim_is('MSFS')
+        # make engine rumble definitely eligible so the joystick control run
+        # proves the effect WOULD fire were it not for the device gate
+        ac.engine_prop_rumble_enabled = True
+        ac.engine_rumble_lowrpm = 600
+        ac.engine_rumble_highrpm = 2700
+        ac.engine_rumble_lowrpm_intensity = 0.1
+        ac.engine_rumble_highrpm_intensity = 0.15
+        return ac
+
+    def _started_effects(self, exclude=("pause_spring",)):
+        return [name for name, eff in self.mock_effects.dict.items()
+                if eff.started and name not in exclude]
+
+    def test_no_effects_run_on_a_trimwheel_device(self):
+        ac = self._aircraft()
+        telem = _telem("trimwheel")
+        ac._telem_data = telem   # same object, like TelemManager does
+        ac.on_telemetry(telem)
+        assert self._started_effects() == [], \
+            f"haptic effects must never play on a trimwheel: {self._started_effects()}"
+
+    def test_engine_rumble_still_runs_on_a_joystick(self):
+        # positive control: identical telemetry on a joystick must start the
+        # prop rumble, so the trimwheel assertion above cannot pass vacuously
+        ac = self._aircraft()
+        telem = _telem("joystick")
+        ac._telem_data = telem   # same object, like TelemManager does
+        ac.on_telemetry(telem)
+        started = self._started_effects()
+        assert any(name.startswith("prop_rpm") for name in started), \
+            f"expected prop rumble on a joystick; started={started}"

--- a/tests/test_trimwheel_mixin.py
+++ b/tests/test_trimwheel_mixin.py
@@ -1,0 +1,212 @@
+"""
+Regression tests for MsfsXpTrimwheelMixIn.
+
+The mixin-split refactor replaced the trimwheel's direct-write mode (the
+default: set the ELEVATOR TRIM POSITION SimVar, mapped through the trim
+travel limits) with ``raise ValueError("Trimwheel must use axis")``, killing
+the mode entirely. These tests pin down both write methods and the
+missing-limits fallbacks so the direct path cannot silently die again.
+"""
+import time
+
+import pytest
+
+import telemffb.globals as G
+from tests.framework.base import BaseTelemetryEffectTestCase
+from tests.framework.utils import TelemetryDataBuilder
+from telemffb.sim.msfs_xp.MsfsXpTrimwheelMixIn import MsfsXpTrimwheelMixIn
+
+
+@pytest.fixture(autouse=True)
+def _reset_trimwheel_hold():
+    G.trimcal_hold_until = 0.0
+    yield
+    G.trimcal_hold_until = 0.0
+
+
+class TestTrimwheelWriteMethods(BaseTelemetryEffectTestCase):
+    def _trimwheel(self, use_axis, phys_y=0.05):
+        instance = self.create_test_instance(
+            MsfsXpTrimwheelMixIn,
+            telemffb_controls_axes=True,
+            trimwheel_use_axis=use_axis,
+        )
+        instance._test_sim_is_msfs = True
+        self.mock_device.get_input().set_axis(x=0.0, y=phys_y)
+        return instance
+
+    def _telem(self, **extra):
+        builder = (
+            TelemetryDataBuilder()
+            .ffb_type("trimwheel")
+            .set("APMaster", 0)
+            .set("ElevTrimPct", 0.0)
+        )
+        for key, value in extra.items():
+            builder.set(key, value)
+        return builder.build()
+
+    def test_direct_mode_writes_trim_position_simvar(self):
+        # THE regression: direct mode (use_axis=False, the class default)
+        # raised ValueError every frame after the refactor instead of writing
+        # the surface position.
+        instance = self._trimwheel(use_axis=False)
+        telem = self._telem(ElevTrim=2.0, ElevTrimMax=10.0, ElevTrimMin=-10.0)
+        instance._telem_data = telem
+
+        instance.msfs_update_trimwheel(telem)
+
+        assert instance.trimwheel_init == 1
+        # spring mirrors the sim trim mapped through the travel limits
+        assert telem["trimwheel_pos_calc"] == pytest.approx(0.2)
+        # phys_y 0.05 -> 0.5 deg -> radians, written to the SimVar directly
+        writes = instance.mock_simconnect.sim_data_written
+        assert ("ELEVATOR TRIM POSITION", pytest.approx(0.5 * 0.01745), "radians") in writes
+        assert not any(e[0] == "AXIS_ELEV_TRIM_SET"
+                       for e in instance.mock_simconnect.sent_events)
+
+    def test_axis_mode_sends_trim_axis_event(self):
+        instance = self._trimwheel(use_axis=True)
+        telem = self._telem()
+        instance._telem_data = telem
+
+        instance.msfs_update_trimwheel(telem)
+
+        # phys_y 0.05 -> scaled to +-16384 and sign-inverted
+        events = instance.mock_simconnect.sent_events
+        assert ("AXIS_ELEV_TRIM_SET", -int(0.05 * 16384)) in events
+        assert instance.mock_simconnect.sim_data_written == []
+
+    def test_direct_mode_without_limits_falls_back_and_does_not_crash(self):
+        # Aircraft that report no trim-limit telemetry: the spring follows
+        # ElevTrimPct and no surface write is attempted (warned once).
+        instance = self._trimwheel(use_axis=False, phys_y=0.3)
+        telem = self._telem(ElevTrimPct=0.3, ElevTrim=2.0)
+        instance._telem_data = telem
+
+        instance.msfs_update_trimwheel(telem)
+
+        assert instance.trimwheel_init == 1
+        assert telem["trimwheel_pos_calc"] == pytest.approx(0.3)
+        # nothing touched SimConnect at all (the lazy mock was never created)
+        assert instance.mock_simconnect is None or \
+            instance.mock_simconnect.sim_data_written == []
+        assert instance._tw_limits_warned
+
+
+class TestTrimwheelCalibrationHold(BaseTelemetryEffectTestCase):
+    """A running trim calibration broadcasts a hold (G.trimcal_hold_until):
+    the wheel keeps following the sim on the spring but must not write back,
+    and on release it re-syncs before sending again."""
+
+    def _trimwheel(self, phys_y=0.05):
+        instance = self.create_test_instance(
+            MsfsXpTrimwheelMixIn,
+            telemffb_controls_axes=True,
+            trimwheel_use_axis=False,
+        )
+        instance._test_sim_is_msfs = True
+        self.mock_device.get_input().set_axis(x=0.0, y=phys_y)
+        return instance
+
+    def _telem(self, elev_trim=2.0):
+        return (TelemetryDataBuilder()
+                .ffb_type("trimwheel")
+                .set("APMaster", 0)
+                .set("ElevTrimPct", 0.0)
+                .set("ElevTrim", elev_trim)
+                .set("ElevTrimMax", 10.0)
+                .set("ElevTrimMin", -10.0)
+                .build())
+
+    def _writes(self, instance):
+        sc = instance.mock_simconnect
+        return [] if sc is None else sc.sim_data_written
+
+    def test_hold_suppresses_writes_but_spring_still_follows(self):
+        instance = self._trimwheel()
+        telem = self._telem()
+        instance._telem_data = telem
+        G.trimcal_hold_until = time.perf_counter() + 5.0
+
+        instance.msfs_update_trimwheel(telem)
+
+        assert instance.trimwheel_init == 1
+        assert self._writes(instance) == [], "no sim writes while held"
+        # the spring mirror keeps running so the wheel tracks the sweep
+        assert telem["trimwheel_pos_calc"] == pytest.approx(0.2)
+
+    def test_hold_release_resyncs_wheel_before_sending(self):
+        instance = self._trimwheel(phys_y=0.05)
+        G.trimcal_hold_until = time.perf_counter() + 5.0
+        telem = self._telem()
+        instance._telem_data = telem
+        instance.msfs_update_trimwheel(telem)
+        assert self._writes(instance) == []
+
+        # calibration ends; wheel (0.05) does not match the sim trim (0.2) yet
+        G.trimcal_hold_until = 0.0
+        telem = self._telem()
+        instance._telem_data = telem
+        instance.msfs_update_trimwheel(telem)
+        assert instance.trim_active, "must latch until the wheel converges"
+        assert self._writes(instance) == [], "no snap-back to the stale wheel position"
+
+        # wheel converges on the sim trim: latch clears and writes resume
+        self.mock_device.get_input().set_axis(y=0.2)
+        telem = self._telem()
+        instance._telem_data = telem
+        instance.msfs_update_trimwheel(telem)
+        assert not instance.trim_active
+        assert len(self._writes(instance)) == 1
+
+    def test_expired_hold_does_not_suppress(self):
+        instance = self._trimwheel()
+        telem = self._telem()
+        instance._telem_data = telem
+        # a crashed master left a stale hold behind: TTL already passed
+        G.trimcal_hold_until = time.perf_counter() - 0.1
+
+        instance.msfs_update_trimwheel(telem)
+
+        assert len(self._writes(instance)) == 1, "expired hold must not mute the wheel"
+
+
+class TestTrimwheelLimitFallbacks(BaseTelemetryEffectTestCase):
+    def _instance(self):
+        return self.create_test_instance(MsfsXpTrimwheelMixIn)
+
+    def test_prefers_max_min_over_up_dn_limits(self):
+        telem = (TelemetryDataBuilder()
+                 .set("ElevTrimMax", 20.0).set("ElevTrimMin", -12.0)
+                 .set("ElevTrimUpLmt", 8.0).set("ElevTrimDnLmt", -8.0)
+                 .build())
+        assert self._instance()._trimwheel_trim_limits(telem) == (-12.0, 20.0)
+
+    def test_up_dn_limits_used_when_max_min_missing(self):
+        telem = (TelemetryDataBuilder()
+                 .set("ElevTrimUpLmt", 8.0).set("ElevTrimDnLmt", -6.0)
+                 .build())
+        assert self._instance()._trimwheel_trim_limits(telem) == (-6.0, 8.0)
+
+    def test_missing_lower_limit_assumes_symmetric_travel(self):
+        telem = TelemetryDataBuilder().set("ElevTrimUpLmt", 12.0).build()
+        assert self._instance()._trimwheel_trim_limits(telem) == (-12.0, 12.0)
+
+    def test_no_usable_limits_returns_none(self):
+        instance = self._instance()
+        assert instance._trimwheel_trim_limits(TelemetryDataBuilder().build()) is None
+        assert instance._tw_limits_warned
+        # degenerate zero-width travel is also unusable
+        telem = (TelemetryDataBuilder()
+                 .set("ElevTrimMax", 5.0).set("ElevTrimMin", 5.0).build())
+        assert instance._trimwheel_trim_limits(telem) is None
+
+    def test_sim_pos_prefers_scaled_elevtrim_else_pct(self):
+        instance = self._instance()
+        telem = (TelemetryDataBuilder()
+                 .set("ElevTrim", 5.0).set("ElevTrimPct", 0.9).build())
+        assert instance._trimwheel_sim_pos(telem, (-10.0, 10.0)) == pytest.approx(0.5)
+        assert instance._trimwheel_sim_pos(telem, None) == pytest.approx(0.9)
+        no_trim = TelemetryDataBuilder().set("ElevTrimPct", 0.9).build()
+        assert instance._trimwheel_sim_pos(no_trim, (-10.0, 10.0)) == pytest.approx(0.9)

--- a/tests/test_trimwheel_mixin.py
+++ b/tests/test_trimwheel_mixin.py
@@ -96,8 +96,9 @@ class TestTrimwheelWriteMethods(BaseTelemetryEffectTestCase):
 
 class TestTrimwheelCalibrationHold(BaseTelemetryEffectTestCase):
     """A running trim calibration broadcasts a hold (G.trimcal_hold_until):
-    the wheel keeps following the sim on the spring but must not write back,
-    and on release it re-syncs before sending again."""
+    the wheel is parked where it sits (the calibrator restores the starting
+    trim, so the parked position is the correct post-run position) and must
+    not write back; on release it re-syncs before sending again."""
 
     def _trimwheel(self, phys_y=0.05):
         instance = self.create_test_instance(
@@ -109,11 +110,11 @@ class TestTrimwheelCalibrationHold(BaseTelemetryEffectTestCase):
         self.mock_device.get_input().set_axis(x=0.0, y=phys_y)
         return instance
 
-    def _telem(self, elev_trim=2.0):
+    def _telem(self, elev_trim=2.0, pct=0.0):
         return (TelemetryDataBuilder()
                 .ffb_type("trimwheel")
                 .set("APMaster", 0)
-                .set("ElevTrimPct", 0.0)
+                .set("ElevTrimPct", pct)
                 .set("ElevTrim", elev_trim)
                 .set("ElevTrimMax", 10.0)
                 .set("ElevTrimMin", -10.0)
@@ -123,8 +124,8 @@ class TestTrimwheelCalibrationHold(BaseTelemetryEffectTestCase):
         sc = instance.mock_simconnect
         return [] if sc is None else sc.sim_data_written
 
-    def test_hold_suppresses_writes_but_spring_still_follows(self):
-        instance = self._trimwheel()
+    def test_hold_suppresses_writes_and_parks_the_wheel(self):
+        instance = self._trimwheel(phys_y=0.05)
         telem = self._telem()
         instance._telem_data = telem
         G.trimcal_hold_until = time.perf_counter() + 5.0
@@ -133,8 +134,16 @@ class TestTrimwheelCalibrationHold(BaseTelemetryEffectTestCase):
 
         assert instance.trimwheel_init == 1
         assert self._writes(instance) == [], "no sim writes while held"
-        # the spring mirror keeps running so the wheel tracks the sweep
-        assert telem["trimwheel_pos_calc"] == pytest.approx(0.2)
+        # the wheel is parked where it sat at hold onset — NOT dragged along
+        # the sweep (chasing the sweep ends displaced and wedges the latch)
+        assert instance.spring_y.cpOffset == pytest.approx(0.05 * 4096, abs=2)
+
+        # sim trim moves during the sweep: the park must not budge
+        telem2 = self._telem(elev_trim=6.0)   # sim trim now 0.6
+        instance._telem_data = telem2
+        instance.msfs_update_trimwheel(telem2)
+        assert instance.spring_y.cpOffset == pytest.approx(0.05 * 4096, abs=2)
+        assert self._writes(instance) == []
 
     def test_hold_release_resyncs_wheel_before_sending(self):
         instance = self._trimwheel(phys_y=0.05)
@@ -159,6 +168,28 @@ class TestTrimwheelCalibrationHold(BaseTelemetryEffectTestCase):
         instance.msfs_update_trimwheel(telem)
         assert not instance.trim_active
         assert len(self._writes(instance)) == 1
+
+    def test_hold_release_near_restored_trim_resumes_immediately(self):
+        # The normal case: the calibrator restored the starting trim, so the
+        # parked wheel is already within the (widened) re-sync tolerance and
+        # the latch must clear on the first frame — no stuck wheel.
+        instance = self._trimwheel(phys_y=0.19)
+        G.trimcal_hold_until = time.perf_counter() + 5.0
+        # wheel was in sync before the run (pct near the wheel so init passes)
+        telem = self._telem(pct=0.19)   # sim trim 0.2; wheel parked at 0.19
+        instance._telem_data = telem
+        instance.msfs_update_trimwheel(telem)
+        assert self._writes(instance) == []
+
+        G.trimcal_hold_until = 0.0
+        telem = self._telem(pct=0.19)
+        instance._telem_data = telem
+        instance.msfs_update_trimwheel(telem)
+        assert not instance.trim_active, \
+            "wheel within post-hold tolerance of the restored trim must unlatch"
+        assert len(self._writes(instance)) == 1
+        assert instance._tw_resync_tol == pytest.approx(0.003), \
+            "tolerance must return to the button-trim default after release"
 
     def test_expired_hold_does_not_suppress(self):
         instance = self._trimwheel()


### PR DESCRIPTION
Follow-up to PR#69, driven by further testing of the auto-calibration across a wide
range of aircraft

## Calibration robustness on difficult aircraft

- Reduce intensity of polarity probe control inputs to avoid inducing oscillation.
- New **Control response** option (Normal / Reduced / Minimal) pre-derates the
  leveling-loop gains for sensitive/aerobatic aircraft
- Sweep stations with a steady 30–60 fpm VS residual are now **accepted and flagged** 
  instead of aborting the whole run
- Polarity probe early-exit now waits for the input ramp to complete, and runs cannot 
  start while climbing/descending — a probe judged against residual aircraft motion 
  could misread pitch polarity and rail the elevator
  
## Direct SimVar trim writes are now the default

- Calibration originally commanded trim via `AXIS_ELEV_TRIM_SET`, which assumes
  the sim maps the event value 1:1 onto the `ELEVATOR TRIM PCT`. Further
  testing found addons that break that assumption.

  Writing the `ELEVATOR TRIM POSITION` SimVar directly (mapped per-side through
  the aircraft's trim travel limits, same approach as the trimwheel's direct
  mode) proved the most reliable method on every aircraft tested.

## Trimwheel fixes

- Restored the trimwheel's direct-write mode, which the mixin refactor had
  replaced with an unconditional `raise` — the default (non-axis) trimwheel
  configuration raised on every telemetry frame. Missing trim-limit telemetry
  now degrades gracefully instead of crashing the frame.
- A running calibration now mutes trimwheel sim writes via a self-expiring
  IPC hold