### PR TITLE
fix(msfs-xp): release X-Plane axis override when FFB device is disconnected

### DIFF
--- a/telemffb/hw/ffb_rhino.py
+++ b/telemffb/hw/ffb_rhino.py
@@ -844,6 +844,15 @@ class FFBRhino(QObject):
         self._dev.nonblocking = True
 
     @property
+    def connected(self) -> bool:
+        """Whether the HID handle is currently open.
+
+        False after a failed read / hot-unplug until reconnect() succeeds.
+        _in_reports intentionally keeps the last (stale) report after a
+        disconnect, so handle state is the only reliable liveness signal.
+        """
+        return self._dev is not None
+    @property
     def serial(self):
         if not self._dev:
             return None

--- a/telemffb/sim/msfs_xp/MsfsXpSimConnectMixIn.py
+++ b/telemffb/sim/msfs_xp/MsfsXpSimConnectMixIn.py
@@ -76,6 +76,7 @@ class MsfsXpSimConnectMixIn(AircraftEffectUtilsBase):
         self._trim_curve_y_pts = None   # transitional single-curve view (median entry) for display
         self._trim_blend_last_v = None  # last valid IAS (kt) fed to the blend — in-frame dropout guard
         self._simconnect_proxy = SimConnectProxy(lambda: G.telem_manager.simconnect if G.telem_manager else None)
+        self._fw_override_supported_last = None
 
     @property
     def joystick_trim_follow_curve_y(self) -> Optional[str]:
@@ -253,18 +254,38 @@ class MsfsXpSimConnectMixIn(AircraftEffectUtilsBase):
     def _firmware_axis_override_supported(self) -> bool:
         if not HapticEffect.device:
             return False
+        if not HapticEffect.device.connected:
+            return False
         return HapticEffect.device.supports_axis_override()
 
     def _use_firmware_axis_backend(self) -> bool:
         if not (self._axis_control_enabled() and self.use_firmware_axis_override):
             return False
         supported = self._firmware_axis_override_supported()
-        if not supported:
-            logging.warning("Firmware axis override requested but not supported; falling back to simulator backend")
+        if supported != self._fw_override_supported_last:
+            self._fw_override_supported_last = supported
+            if not supported:
+                logging.warning(
+                    "Firmware axis override requested but not supported; "
+                    "falling back to simulator backend")
         return supported
 
     def _use_sim_axis_backend(self) -> bool:
         return self._axis_control_enabled() and not self._use_firmware_axis_backend()
+
+    def _device_feeding(self) -> bool:
+        """Whether the FFB device is connected and delivering HID input.
+
+        Axis overrides must never be claimed without a live device: the
+        plugin pins the virtual yoke/rudder to whatever we send, so a dead
+        instance would feed zeros/stale values and silence the user's real
+        controller. Re-checked every frame, so a hot-unplug releases the
+        override and a reconnect reclaims it.
+        """
+        device = HapticEffect.device
+        if device is None or not device.connected:
+            return False
+        return device.get_input() is not None
 
     def _send_firmware_axis_override(self, x_mode=0, x_value=0, y_mode=0, y_value=0, watchdog_ms=1000):
         if not self._use_firmware_axis_backend():
@@ -368,16 +389,21 @@ class MsfsXpSimConnectMixIn(AircraftEffectUtilsBase):
                 self.__xplane_axis_override_active = False
             return
 
+        feeding = self._device_feeding()
+
         if (
             self.telemffb_controls_axes
             and not self.local_disable_axis_control
+            and feeding
             and not self.__xplane_axis_override_active
         ):
             sendstr = f"OVERRIDE:{self.telem_data.FFBType}=true"
             self._socket.sendto(bytes(sendstr, "utf-8"), self.__xplane_addr)
             logging.info(f"Sending to XPLANE: >>{sendstr}<<")
             self.__xplane_axis_override_active = True
-        elif self.__xplane_axis_override_active and not self.telemffb_controls_axes:
+        elif self.__xplane_axis_override_active and (
+            not self.telemffb_controls_axes or not feeding
+        ):
             sendstr = f"OVERRIDE:{self.telem_data.FFBType}=false"
             self._socket.sendto(bytes(sendstr, "utf-8"), self.__xplane_addr)
             logging.info(f"Sending to XPLANE: >>{sendstr}<<")

--- a/tests/framework/base.py
+++ b/tests/framework/base.py
@@ -75,8 +75,16 @@ class MockFFBDevice:
     
     def __init__(self):
         self._input_data = MockInputData()
+        self._connected = True
         self.axis_override_commands = []
-    
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+    def set_connected(self, value: bool):
+        self._connected = value
+
     def get_input(self) -> MockInputData:
         """Return mock input data."""
         return self._input_data

--- a/tests/test_ffb_rhino.py
+++ b/tests/test_ffb_rhino.py
@@ -883,5 +883,20 @@ class TestDeviceInfo:
         assert info.ident == "My Custom Device"
 
 
+# ============================================================================
+# Connection State Tests
+# ============================================================================
+
+class TestFFBRhinoConnected:
+    """`connected` must mirror the HID handle, not the stale report cache."""
+
+    def test_connected_tracks_hid_handle(self, mock_ffb_device):
+        assert mock_ffb_device.connected is True
+        mock_ffb_device._dev = None  # what timerEvent does on a failed read
+        assert mock_ffb_device.connected is False
+        mock_ffb_device._dev = MockHIDDevice()  # what reconnect() restores
+        assert mock_ffb_device.connected is True
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])

--- a/tests/test_xplane_axis_override_gate.py
+++ b/tests/test_xplane_axis_override_gate.py
@@ -1,0 +1,124 @@
+"""
+Device-loss gate for the X-Plane axis override (MsfsXpSimConnectMixIn).
+
+A TelemFFB instance whose FFB device is not live must never claim the
+simulator's axis control: the plugin pins the virtual yoke/rudder to the
+values we send, so a dead instance would feed zeros (or stale values) and
+silence the user's real controller. The gate must release an active
+override when the device is lost and reclaim it when the device returns.
+"""
+import telemffb.globals as G
+from telemffb.hw.ffb_rhino import HapticEffect
+from tests.framework.base import BaseTelemetryEffectTestCase
+from tests.framework.utils import TelemetryDataBuilder
+from telemffb.sim.msfs_xp.MsfsXpSimConnectMixIn import MsfsXpSimConnectMixIn
+
+# annotation-only in globals; None = no firmware version (see test_blade_slap.py)
+G.device_firmware_version = getattr(G, "device_firmware_version", None)
+
+
+class RecordingSocket:
+    """Stands in for the UDP socket; records every command string."""
+
+    def __init__(self):
+        self.sent = []
+
+    def sendto(self, data, addr):
+        self.sent.append(data.decode("utf-8"))
+
+
+class TestXpAxisOverrideDeviceGate(BaseTelemetryEffectTestCase):
+
+    def setup_method(self):
+        super().setup_method()
+        self._orig_device_type = G.device_type
+        G.device_type = "joystick"  # not reset by the shared fixture
+
+    def teardown_method(self):
+        G.device_type = self._orig_device_type
+        super().teardown_method()
+
+    def _instance(self, ffb_type="joystick"):
+        instance = self.create_test_instance(MsfsXpSimConnectMixIn)
+        instance._socket = RecordingSocket()
+        instance.telemffb_controls_axes = True
+        telem = TelemetryDataBuilder().ffb_type(ffb_type).build()
+        self.set_telemetry(instance, telem)
+        return instance
+
+    def test_device_never_connected_never_claims_override(self):
+        HapticEffect.device = None  # open() failed at startup
+        instance = self._instance()
+        instance.toggle_xp_control()
+        assert instance._socket.sent == []
+
+    def test_device_feeding_claims_override_once(self):
+        instance = self._instance()  # base fixture: MockFFBDevice, connected
+        instance.toggle_xp_control()
+        assert instance._socket.sent == ["OVERRIDE:joystick=true"]
+        instance.toggle_xp_control()  # steady state: no resend
+        assert instance._socket.sent == ["OVERRIDE:joystick=true"]
+
+    def test_hot_unplug_releases_override(self):
+        instance = self._instance()
+        instance.toggle_xp_control()
+        assert instance._socket.sent == ["OVERRIDE:joystick=true"]
+        # _in_reports keeps the last stale report on a real device —
+        # connected is the only reliable liveness signal.
+        self.mock_device.set_connected(False)
+        instance.toggle_xp_control()
+        assert instance._socket.sent == [
+            "OVERRIDE:joystick=true", "OVERRIDE:joystick=false",
+        ]
+        instance.toggle_xp_control()  # stays released, no flapping
+        assert instance._socket.sent == [
+            "OVERRIDE:joystick=true", "OVERRIDE:joystick=false",
+        ]
+
+    def test_reconnect_reclaims_override(self):
+        instance = self._instance()
+        instance.toggle_xp_control()
+        self.mock_device.set_connected(False)
+        instance.toggle_xp_control()
+        self.mock_device.set_connected(True)
+        instance.toggle_xp_control()
+        assert instance._socket.sent == [
+            "OVERRIDE:joystick=true",
+            "OVERRIDE:joystick=false",
+            "OVERRIDE:joystick=true",
+        ]
+
+    def test_fresh_connect_without_reports_yet_holds_override(self):
+        instance = self._instance()
+        self.mock_device._input_data = None  # connected, first report pending
+        instance.toggle_xp_control()
+        assert instance._socket.sent == []
+
+    def test_controls_disabled_while_active_still_releases(self):
+        instance = self._instance()
+        instance.toggle_xp_control()
+        instance.telemffb_controls_axes = False
+        instance.toggle_xp_control()
+        assert instance._socket.sent == [
+            "OVERRIDE:joystick=true", "OVERRIDE:joystick=false",
+        ]
+
+    def test_pedals_device_never_connected_never_claims_override(self):
+        HapticEffect.device = None
+        instance = self._instance(ffb_type="pedals")
+        instance.toggle_xp_control()
+        assert instance._socket.sent == []
+
+    def test_firmware_backend_warning_only_on_transition(self, caplog):
+        import logging
+        instance = self._instance()
+        instance.use_firmware_axis_override = True
+        self.mock_device.set_connected(False)  # not supported while dead
+        with caplog.at_level(logging.WARNING):
+            instance.toggle_xp_control()
+            instance.toggle_xp_control()
+            instance.toggle_xp_control()
+        warnings = [r for r in caplog.records
+                    if "Firmware axis override" in r.message]
+        assert len(warnings) == 1
+        assert instance._socket.sent == []


### PR DESCRIPTION
## Problem

A TelemFFB joystick instance whose FFB device (Rhino) is disconnected keeps claiming the X-Plane plugin's axis override: `toggle_xp_control()` sent `OVERRIDE:joystick=true` purely on the `telemffb_controls_axes` setting, never checking device liveness, and the only release path was turning the setting off. With the override latched, every per-frame `AXIS:jx/jy` (fed from the dead device's stale/zero input report) is written straight into X-Plane's yoke pitch/roll datarefs — pinning the user's real stick (pitch/roll lockout) until app restart or device reconnect.

## Changes

- `feat(hw)`: add `FFBRhino.connected` property mirroring the live HID handle (`_dev is not None`). The `_in_reports` last-report cache is deliberately not a liveness signal (it keeps stale data after a hot-unplug). `MockFFBDevice` gains the matching `_connected` state and `set_connected()` for tests.
- `fix(msfs-xp)`: gate the override in `MsfsXpSimConnectMixIn` — a new `_device_feeding()` helper requires the device to be connected **and** delivering input; `toggle_xp_control()` claims `OVERRIDE:{FFBType}=true` only while feeding and actively sends `=false` on the first frame feeding is lost; firmware-backend support check gains the same connected guard; the firmware-fallback warning now fires only on state transitions (no per-frame log spam).

Wire protocol unchanged (`OVERRIDE:{FFBType}=true|false` already existed in both directions) — **no plugin change required**. MSFS axis path, collective, and trimwheel branches untouched.

## Verification

- 9 new tests (1 hw property test through real connect/null/restore states; 8 behavioral tests asserting exact wire strings via a recording socket: never-connected, hot-unplug release, re-claim on reconnect, no flapping, firmware fallback cadence).
- Full suite on the rebased base: 1009 passed, 17 failed — the 17 are the pre-existing Windows-platform failures (identical set before this work); zero new failures.
- Final whole-branch review: ready to land (end-to-end trace of all three scenarios; per-process/multi-instance safe; 60-120 Hz path stays O(1)).

## Known limitations (out of scope)

- Sim exit mid-session leaves the plugin's yoke drefs latched (no telemetry frames → no release); remedy is the plugin's "Clear All Overrides" menu; a plugin-side idle timeout would be the proper fix.
- After a reconnect, the override can re-claim one frame before the first fresh input report (stale report presence); the values sent are correct (they derive from sim telemetry) and the window is bounded by the 1 kHz input stream.