### PR TITLE
fix(xml): a device-scope switch no longer loses the parsed trees

### DIFF
--- a/telemffb/xml/store.py
+++ b/telemffb/xml/store.py
@@ -25,6 +25,20 @@ class XmlStore:
         self._user_root: Optional[ET.Element] = None
         self._defaults_root: Optional[ET.Element] = None
 
+    def adopt_trees_from(self, other: "XmlStore") -> None:
+        """Take over another store's parsed trees without re-parsing.
+
+        The legacy module's update_vars() never invalidated the parsed
+        trees - they persisted until the next update_roots().  The
+        facade recreates the store when the active device changes (the
+        master's device-scope switch does this and reads immediately),
+        so the new store must inherit the trees or every read returns
+        empty until something happens to re-parse.
+        """
+        self._user_tree = other._user_tree
+        self._user_root = other._user_root
+        self._defaults_root = other._defaults_root
+
     @property
     def user_tree(self) -> Optional[ET.ElementTree]:
         return self._user_tree

--- a/telemffb/xmlutils.py
+++ b/telemffb/xmlutils.py
@@ -114,6 +114,14 @@ def _get_mgr() -> tuple[XmlStore, ConfigResolver, ConfigWriter]:
             _mgr[0].userconfig_path != userconfig_path or
             _mgr[0].defaults_path != defaults_path):
         store = XmlStore(device, userconfig_path, defaults_path)
+        if _mgr is not None:
+            # Legacy semantics: update_vars() never invalidated the parsed
+            # trees; they persist until the next update_roots().  The
+            # master's device-scope switch relies on this - it changes the
+            # device and reads immediately, and a fresh empty store made
+            # every read return nothing (the aircraft came back unknown
+            # and the new-aircraft wizard fired).
+            store.adopt_trees_from(_mgr[0])
         resolver = ConfigResolver(store)
         writer = ConfigWriter(store, resolver)
         _mgr = (store, resolver, writer)

--- a/tests/test_xmlutils.py
+++ b/tests/test_xmlutils.py
@@ -372,6 +372,34 @@ class TestUpdateVarsAndRoots:
 # read_xml_file
 # ─────────────────────────────────────────────────────────────
 
+class TestDeviceScopeSwitchKeepsTrees:
+    """Changing the active device must not lose the parsed trees.
+
+    The legacy module's update_vars() only set globals; the parsed trees
+    persisted until the next update_roots().  The master's device-scope
+    switch (MainWindow, viewing a child instance's settings) changes the
+    device and reads immediately - with the facade rebuilding an EMPTY
+    store on device change, every read returned nothing, the loaded
+    aircraft came back unknown, and the new-aircraft wizard fired
+    (field regression after the merge)."""
+
+    def test_reads_survive_a_device_change_without_update_roots(
+            self, xml_tmpdir):
+        before = xmlutils.read_xml_file("MSFS", "joystick")
+        assert before                      # parsed and readable
+
+        xmlutils.update_vars("pedals", xml_tmpdir["userconfig"],
+                             xml_tmpdir["defaults"])
+        after = xmlutils.read_xml_file("MSFS", "joystick")
+        assert after == before             # same trees, no re-parse needed
+
+    def test_switching_back_and_forth_keeps_reading(self, xml_tmpdir):
+        for dev in ("pedals", "collective", "joystick", "trimwheel"):
+            xmlutils.update_vars(dev, xml_tmpdir["userconfig"],
+                                 xml_tmpdir["defaults"])
+            assert xmlutils.read_xml_file("MSFS", "joystick")
+
+
 class TestReadXmlFile:
     def test_returns_settings_for_matching_sim_device(self, xml_tmpdir):
         result = xmlutils.read_xml_file("MSFS", "joystick")


### PR DESCRIPTION
The facade rebuilds the XmlStore when the active device changes, and a fresh store has no parsed trees until update_roots() - but the legacy update_vars() never invalidated the trees, and the master's device persona switch relies on that: it changes the device and reads immediately.  Every read then returned empty, the loaded aircraft came back unknown, and the new-aircraft wizard fired.  A recreated store now adopts the previous store's trees, restoring the legacy invariant that parsed trees persist until the next explicit update_roots().