### PR TITLE
refactor(ffb): normalize remaining spring center paths

### DIFF
--- a/telemffb/sim/aircrafts_dcs.py
+++ b/telemffb/sim/aircrafts_dcs.py
@@ -48,7 +48,7 @@ from telemffb.sim.aircraft_base import AircraftBase
 from telemffb.telem.DcsIpcThread import DcsIpcThread
 from telemffb.SettingsManager import SpringModeEnum
 
-from telemffb.util.conversions import kt2ms, kmh2ms, ms2kmh, deg
+from telemffb.util.conversions import FFB_UNITS, kt2ms, kmh2ms, ms2kmh, deg
 from telemffb.sim.BaseTelemetryData import BaseTelemetryData
 
 LPFs = utils.Dispenser(utils.LowPassFilter)
@@ -128,8 +128,8 @@ class Aircraft(AircraftBase, DCSCommands):
     collective_spring_coeff_y = 0
     last_collective_y = 0
     collective_ap_spring_gain = 4096
-    cpO_x = 0
-    cpO_y = 0
+    cpO_x: float = 0.0
+    cpO_y: float = 0.0
 
     dcs_tr_damper_enabled = False
     dcs_tr_button = 0
@@ -146,8 +146,8 @@ class Aircraft(AircraftBase, DCSCommands):
     override_spring_trim_up = 0
     override_spring_trim_right = 0
     override_spring_trim_rate = 200
-    override_spring_cp0_x = 0
-    override_spring_cp0_y = 0
+    override_spring_cp0_x: float = 0.0
+    override_spring_cp0_y: float = 0.0
 
     cp_spr_override_enabled = False
     cp_spr_override_pilot_seat_id = 0
@@ -291,7 +291,7 @@ class Aircraft(AircraftBase, DCSCommands):
         # self.damper = effects["collective_damper"].damper()
         if not self.force_disable_collective_gain:
             self.spring_y.set_coefficient(1.0)
-            self.spring_y.set_offset(0)
+            self.spring_y.set_offset(0.0)
             self.spring.setCondition(self.spring_y)
             self.spring.start(override=True)
             return
@@ -303,12 +303,12 @@ class Aircraft(AircraftBase, DCSCommands):
 
             self.spring_y.set_coefficient(1.0)
             if max(telem_data.WeightOnWheels):
-                self.cpO_y = 4096
+                self.cpO_y = 1.0
             elif self.last_collective_y is None:
                 # Air start or new aircraft.  Use current physical position as init point
-                self.cpO_y = round(4096 * phys_y)
+                self.cpO_y = float(utils.clamp(phys_y, -1.0, 1.0))
             else:
-                self.cpO_y = round(4096 * self.last_collective_y)
+                self.cpO_y = float(utils.clamp(self.last_collective_y, -1.0, 1.0))
 
             self.spring_y.set_offset(self.cpO_y)
 
@@ -316,7 +316,7 @@ class Aircraft(AircraftBase, DCSCommands):
             # self.damper.damper(coef_y=int(4096 * self.collective_dampening_gain)).start()
             self.spring.start(override=True)
             # print(f"self.cpO_y:{self.cpO_y}, phys_y:{phys_y}")
-            if self.cpO_y / 4096 - 0.1 < phys_y < self.cpO_y / 4096 + 0.1:
+            if self.cpO_y - 0.1 < phys_y < self.cpO_y + 0.1:
                 # dont start sending position until physical stick has centered
                 self.collective_init = 1
                 logging.info("Collective Initialized")
@@ -329,7 +329,7 @@ class Aircraft(AircraftBase, DCSCommands):
             self.ac_collective_force_trim_override(telem_data, self.spring)
         else:
             self.spring.name = "collective_ap_spring"
-            self.cpO_y = round(4096 * utils.clamp(phys_y, -1, 1))
+            self.cpO_y = float(utils.clamp(phys_y, -1.0, 1.0))
             self.spring_y.set_offset(self.cpO_y)
 
             # self.damper.damper(coef_y=int(4096 * self.collective_dampening_gain)).start()
@@ -354,7 +354,7 @@ class Aircraft(AircraftBase, DCSCommands):
         lp_x = LPFs.get("x", 5)
         # estimate trim from real stick position and virtual stick position
         offs_x = lp_x.update(pedal_pos - x - lp_x.value)
-        self.spring_x.cpOffset = utils.clamp_minmax(round(offs_x * 4096), 4096)
+        self.spring_x.set_offset(float(utils.clamp(offs_x, -1.0, 1.0)))
         self.spring = self.effects["pedal_spring"].spring()
         self.spring.setCondition(self.spring_x)
         self.spring.start(override=True)
@@ -534,10 +534,10 @@ class Aircraft(AircraftBase, DCSCommands):
                 self.spring_x.set_coefficient(gain)
                 self.spring_y.set_coefficient(gain)
 
-                self.override_spring_cp0_x = round(x * 4096)
+                self.override_spring_cp0_x = float(utils.clamp(x, -1.0, 1.0))
                 self.spring_x.set_offset(self.override_spring_cp0_x)
 
-                self.override_spring_cp0_y = round(y * 4096)
+                self.override_spring_cp0_y = float(utils.clamp(y, -1.0, 1.0))
                 self.spring_y.set_offset(self.override_spring_cp0_y)
                 spring.setCondition(self.spring_x)
                 spring.setCondition(self.spring_y)
@@ -547,13 +547,15 @@ class Aircraft(AircraftBase, DCSCommands):
             elif self.override_spring_trim_reset and self.override_spring_trim_reset in current_buttons:
                 # if trim reset button pressed, set offsets back to 0
                 # print("TRIM RESET")
-                self.spring_x.cpOffset = self.override_spring_cp0_x = 0
-                self.spring_y.cpOffset = self.override_spring_cp0_y = 0
+                self.override_spring_cp0_x = 0.0
+                self.override_spring_cp0_y = 0.0
+                self.spring_x.set_offset(self.override_spring_cp0_x)
+                self.spring_y.set_offset(self.override_spring_cp0_y)
                 spring.setCondition(self.spring_x)
                 spring.setCondition(self.spring_y)
 
             # calculate step size based on configured rate and delta time
-            trim_step_size = self.override_spring_trim_rate * dt
+            trim_step_size = self.override_spring_trim_rate * dt / FFB_UNITS
 
             self.telem_data._ovrd_spr_step = trim_step_size
 
@@ -562,38 +564,33 @@ class Aircraft(AircraftBase, DCSCommands):
             if self.override_spring_trim_down and self.override_spring_trim_down in current_buttons:
                 # shift offset based on previously calculated step size.  Ensure value does not exceed limits
                 # print("TRIM DOWN")
-                if self.override_spring_cp0_y - trim_step_size < -4096:
-                    self.override_spring_cp0_y = -4096
-                else:
-                    self.override_spring_cp0_y -= trim_step_size
-                self.spring_y.cpOffset = round(self.override_spring_cp0_y)
+                self.override_spring_cp0_y = utils.clamp(
+                    self.override_spring_cp0_y - trim_step_size, -1.0, 1.0)
+                self.spring_y.set_offset(self.override_spring_cp0_y)
             elif self.override_spring_trim_up and self.override_spring_trim_up in current_buttons:
                 # shift offset based on previously calculated step size.  Ensure value does not exceed limits
                 # print("TRIM UP")
-                if self.override_spring_cp0_y + trim_step_size > 4096:
-                    self.override_spring_cp0_y = 4096
-                else:
-                    self.override_spring_cp0_y += trim_step_size
-                self.spring_y.cpOffset = round(self.override_spring_cp0_y)
+                self.override_spring_cp0_y = utils.clamp(
+                    self.override_spring_cp0_y + trim_step_size, -1.0, 1.0)
+                self.spring_y.set_offset(self.override_spring_cp0_y)
 
             if self.override_spring_trim_left and self.override_spring_trim_left in current_buttons:
                 # shift offset based on previously calculated step size.  Ensure value does not exceed limits
                 # print("TRIM LEFT")
-                if self.override_spring_cp0_x - trim_step_size < -4096:
-                    self.override_spring_cp0_x = -4096
-                else:
-                    self.override_spring_cp0_x -= trim_step_size
-                self.spring_x.cpOffset = round(self.override_spring_cp0_x)
+                self.override_spring_cp0_x = utils.clamp(
+                    self.override_spring_cp0_x - trim_step_size, -1.0, 1.0)
+                self.spring_x.set_offset(self.override_spring_cp0_x)
             elif self.override_spring_trim_right and self.override_spring_trim_right in current_buttons:
                 # shift offset based on previously calculated step size.  Ensure value does not exceed limits
                 # print("TRIM RIGHT")
-                if self.override_spring_cp0_x + trim_step_size > 4096:
-                    self.override_spring_cp0_x = 4096
-                else:
-                    self.override_spring_cp0_x += trim_step_size
-                self.spring_x.cpOffset = round(self.override_spring_cp0_x)
+                self.override_spring_cp0_x = utils.clamp(
+                    self.override_spring_cp0_x + trim_step_size, -1.0, 1.0)
+                self.spring_x.set_offset(self.override_spring_cp0_x)
 
-        self.telem_data._ovrd_spr_trim_pos = [round(self.override_spring_cp0_x), round(self.override_spring_cp0_y)]
+        self.telem_data._ovrd_spr_trim_pos = [
+            self.override_spring_cp0_x,
+            self.override_spring_cp0_y,
+        ]
 
         # If trim release is not pressed, set spring gain based on user setting and start spring override
         self.spring_x.set_coefficient(self.override_spring_gain)

--- a/telemffb/sim/aircrafts_il2.py
+++ b/telemffb/sim/aircrafts_il2.py
@@ -437,38 +437,10 @@ class Aircraft(AircraftBase):
 
         if self.override_spring_ft_enabled:
             input_data = self._get_device_report()
-            x, y = self._get_device_axes()
             current_buttons = input_data.getPressedButtons() if input_data is not None else []
-            # print(f"BUTTONS:>{current_buttons}<")
-            # decide what to do depending on which button is pressed
-            # if self.override_spring_trim_release and self.override_spring_trim_release in current_buttons:
-            #     # use spring force as dampening.  Configured damper value applied as spring gain.  cpO will follow stick
-            #     # as it is moved while spring force is enabled.
-            #     # return from method so default spring gains do not get applied at the end of the method
-            #     gain = int(self.override_spring_tr_damper * 4096)
-            #     self.spring_x.set_coefficient(gain)
-            #     self.spring_y.set_coefficient(gain)
-            #
-            #     self.override_spring_cp0_x = round(x * 4096)
-            #     self.spring_x.set_offset(self.override_spring_cp0_x)
-            #
-            #     self.override_spring_cp0_y = round(y * 4096)
-            #     self.spring_y.set_offset(self.override_spring_cp0_y)
-            #     spring.setCondition(self.spring_x)
-            #     spring.setCondition(self.spring_y)
-            #     spring.start(override=True)
-            #     return
-
-            # elif self.override_spring_trim_reset and self.override_spring_trim_reset in current_buttons:
-            #     # if trim reset button pressed, set offsets back to 0
-            #     # print("TRIM RESET")
-            #     self.spring_x.cpOffset = self.override_spring_cp0_x = 0
-            #     self.spring_y.cpOffset = self.override_spring_cp0_y = 0
-            #     spring.setCondition(self.spring_x)
-            #     spring.setCondition(self.spring_y)
 
             # calculate step size based on configured rate and delta time
-            trim_step_size = self.override_spring_trim_rate * dt
+            trim_step_size = self.override_spring_trim_rate * dt / conv.FFB_UNITS
 
             self.telem_data._ovrd_spr_step = trim_step_size
 
@@ -477,38 +449,33 @@ class Aircraft(AircraftBase):
             if self.override_spring_trim_down and self.override_spring_trim_down in current_buttons:
                 # shift offset based on previously calculated step size.  Ensure value does not exceed limits
                 # print("TRIM DOWN")
-                if self.override_spring_cp0_y - trim_step_size < -4096:
-                    self.override_spring_cp0_y = -4096
-                else:
-                    self.override_spring_cp0_y -= trim_step_size
-                self.spring_y.cpOffset = round(self.override_spring_cp0_y)
+                self.override_spring_cp0_y = utils.clamp(
+                    self.override_spring_cp0_y - trim_step_size, -1.0, 1.0)
+                self.spring_y.set_offset(self.override_spring_cp0_y)
             elif self.override_spring_trim_up and self.override_spring_trim_up in current_buttons:
                 # shift offset based on previously calculated step size.  Ensure value does not exceed limits
                 # print("TRIM UP")
-                if self.override_spring_cp0_y + trim_step_size > 4096:
-                    self.override_spring_cp0_y = 4096
-                else:
-                    self.override_spring_cp0_y += trim_step_size
-                self.spring_y.cpOffset = round(self.override_spring_cp0_y)
+                self.override_spring_cp0_y = utils.clamp(
+                    self.override_spring_cp0_y + trim_step_size, -1.0, 1.0)
+                self.spring_y.set_offset(self.override_spring_cp0_y)
 
             if self.override_spring_trim_left and self.override_spring_trim_left in current_buttons:
                 # shift offset based on previously calculated step size.  Ensure value does not exceed limits
                 # print("TRIM LEFT")
-                if self.override_spring_cp0_x - trim_step_size < -4096:
-                    self.override_spring_cp0_x = -4096
-                else:
-                    self.override_spring_cp0_x -= trim_step_size
-                self.spring_x.cpOffset = round(self.override_spring_cp0_x)
+                self.override_spring_cp0_x = utils.clamp(
+                    self.override_spring_cp0_x - trim_step_size, -1.0, 1.0)
+                self.spring_x.set_offset(self.override_spring_cp0_x)
             elif self.override_spring_trim_right and self.override_spring_trim_right in current_buttons:
                 # shift offset based on previously calculated step size.  Ensure value does not exceed limits
                 # print("TRIM RIGHT")
-                if self.override_spring_cp0_x + trim_step_size > 4096:
-                    self.override_spring_cp0_x = 4096
-                else:
-                    self.override_spring_cp0_x += trim_step_size
-                self.spring_x.cpOffset = round(self.override_spring_cp0_x)
+                self.override_spring_cp0_x = utils.clamp(
+                    self.override_spring_cp0_x + trim_step_size, -1.0, 1.0)
+                self.spring_x.set_offset(self.override_spring_cp0_x)
 
-        self.telem_data._ovrd_spr_trim_pos = [round(self.override_spring_cp0_x), round(self.override_spring_cp0_y)]
+        self.telem_data._ovrd_spr_trim_pos = [
+            self.override_spring_cp0_x,
+            self.override_spring_cp0_y,
+        ]
 
         # If trim release is not pressed, set spring gain based on user setting and start spring override
         self.spring_x.set_coefficient(self.override_spring_gain)

--- a/telemffb/sim/base/AdvancedSpringMixIn.py
+++ b/telemffb/sim/base/AdvancedSpringMixIn.py
@@ -9,6 +9,7 @@ from telemffb.SettingsManager import GEffectModeEnum, SpringModeEnum
 from telemffb.hw.ffb_rhino import FFBReport_SetCondition
 from telemffb.sim.base.GForceEffectMixIn import GForceEffectMixIn
 from telemffb.sim.BaseTelemetryData import BaseTelemetryData
+from telemffb.util.conversions import FFB_UNITS
 
 perftracker = utils.PerformanceTracker()
 
@@ -125,8 +126,7 @@ class AdvancedSpringMixIn(GForceEffectMixIn, DynamicSpringMixin):
 
         if self.adv_spr_use_hardware_trim:
             dt = perftracker.get_time_delta('override_spring_perf')
-            trim_step_size = self.override_spring_trim_rate * dt
-            # trim_step_size = 200 * dt
+            trim_step_size = self.override_spring_trim_rate * dt / FFB_UNITS
             self.telem_data._ovrd_spr_step = trim_step_size
             self.telem_data._ovrd_spr_dt = dt
             # evaluate UP or DOWN and then LEFT or RIGHT trims.  Allows movement on both axes simultaneously but not
@@ -135,8 +135,8 @@ class AdvancedSpringMixIn(GForceEffectMixIn, DynamicSpringMixin):
             x, y = self._get_device_axes()
             current_buttons = input_data.getPressedButtons() if input_data is not None else ()
             if self.override_spring_trim_reset and self.override_spring_trim_reset in current_buttons:
-                self.override_spring_cp0_x = 0
-                self.override_spring_cp0_y = 0
+                self.override_spring_cp0_x = 0.0
+                self.override_spring_cp0_y = 0.0
 
             if self.override_spring_trim_down and self.override_spring_trim_down in current_buttons:
                 self.override_spring_cp0_y -= trim_step_size
@@ -148,17 +148,21 @@ class AdvancedSpringMixIn(GForceEffectMixIn, DynamicSpringMixin):
             elif self.override_spring_trim_right and self.override_spring_trim_right in current_buttons:
                 self.override_spring_cp0_x += trim_step_size
 
-            self.override_spring_cp0_x = round(utils.clamp(self.override_spring_cp0_x, -4096, 4096))
-            self.override_spring_cp0_y = round(utils.clamp(self.override_spring_cp0_y, -4096, 4096))
+            self.override_spring_cp0_x = utils.clamp(self.override_spring_cp0_x, -1.0, 1.0)
+            self.override_spring_cp0_y = utils.clamp(self.override_spring_cp0_y, -1.0, 1.0)
         else:
-            self.override_spring_cp0_x = 0
-            self.override_spring_cp0_y = 0
+            self.override_spring_cp0_x = 0.0
+            self.override_spring_cp0_y = 0.0
 
         offset = super().ac_update_gforce_effect(self.telem_data, adv_spr=True)  # Returns g force spring offset if effect enabled and in offset mode
-        g_y_offset = offset if offset is not None else 0
-        self.telem_data._ovrd_spr_trim_pos = [round(self.override_spring_cp0_x), round(self.override_spring_cp0_y), g_y_offset]
-        self.spring_adjuster_y.set_offset(round(self.override_spring_cp0_y + g_y_offset))
-        self.spring_adjuster_x.set_offset(round(self.override_spring_cp0_x))
+        g_y_offset = offset if offset is not None else 0.0
+        self.telem_data._ovrd_spr_trim_pos = [
+            self.override_spring_cp0_x,
+            self.override_spring_cp0_y,
+            g_y_offset,
+        ]
+        self.spring_adjuster_y.set_offset(self.override_spring_cp0_y + g_y_offset)
+        self.spring_adjuster_x.set_offset(self.override_spring_cp0_x)
 
         adjuster = self.effects['adv_spr'].spring_adjuster()
         adjuster.setCondition(self.spring_adjuster_y)
@@ -166,7 +170,7 @@ class AdvancedSpringMixIn(GForceEffectMixIn, DynamicSpringMixin):
         adjuster.start()
 
     @override
-    def ac_update_gforce_effect(self, telem_data: BaseTelemetryData, adv_spr: bool = False) -> Optional[int]:
+    def ac_update_gforce_effect(self, telem_data: BaseTelemetryData, adv_spr: bool = False) -> Optional[float]:
         """If advanced spring is enabled and in offset mode, handle gforce effect as part of advanced spring processing.
         else defer to GForceEffectMixIn implementation."""
         if not (self.gforce_effect_mode_is(GEffectModeEnum.ADVANCED) and self.g_effect_get_adv_mode() == "offset"):

--- a/telemffb/sim/base/GForceEffectMixIn.py
+++ b/telemffb/sim/base/GForceEffectMixIn.py
@@ -258,7 +258,9 @@ class GForceEffectMixIn(AircraftEffectUtilsBase, GForceEffectProperties):
     def g_effect_get_adv_mode(self) -> Literal["constant", "offset"]:
         return self.gforce_effect_adv_curve.get("mode", "constant") if self.gforce_effect_adv_curve else "constant"
            
-    def ac_update_gforce_effect(self, telem_data: BaseTelemetryData, adv_spr=False):
+    def ac_update_gforce_effect(
+            self, telem_data: BaseTelemetryData, adv_spr: bool = False
+    ) -> Optional[float]:
         """Dispatch to the configured G-force effect mode (DISABLED/LEGACY/ADVANCED/NEW).
 
         Telemetry:
@@ -361,8 +363,10 @@ class GForceEffectMixIn(AircraftEffectUtilsBase, GForceEffectProperties):
                 g_factor = utils.clamp(g_factor, 0.0, 1.0)
                 self.effects["gforce"].constant(g_factor, direction).start()
 
-            elif mode == "offset":               
-                adjuster_cpOy = int(-g_factor * 4096)
+            elif mode == "offset":
+                # Keep the center shift normalized. set_offset() performs the
+                # sole conversion to Rhino device units at the HID boundary.
+                adjuster_cpOy = -float(g_factor)
 
                 if adv_spr:
                     # If being called by advanced spring effect, don't apply adjuster offset here, return offset value and let the advanced spring adjuster effect do it
@@ -383,7 +387,7 @@ class GForceEffectMixIn(AircraftEffectUtilsBase, GForceEffectProperties):
                     # change to coefficient=4096/saturation=1 clamped the
                     # adjusted spring's output to ~zero - all spring force died
                     # the moment the effect started.
-                    cond_x.set_offset(0)
+                    cond_x.set_offset(0.0)
                     cond_x.positiveSaturation = cond_x.negativeSaturation = 4096
                     cond_y.set_offset(adjuster_cpOy)
                     cond_y.positiveSaturation = cond_y.negativeSaturation = 4096

--- a/telemffb/sim/base/HelicopterEffectsMixIn.py
+++ b/telemffb/sim/base/HelicopterEffectsMixIn.py
@@ -6,6 +6,7 @@ from telemffb.SettingsManager import SpringModeEnum
 from telemffb.hw.ffb_rhino import EFFECT_SAWTOOTHDOWN, EFFECT_SQUARE
 from telemffb.sim.base.AdvancedSpringMixIn import AdvancedSpringMixIn
 from telemffb.sim.BaseTelemetryData import BaseTelemetryData
+from telemffb.util.conversions import FFB_UNITS
 
 perftracker = utils.PerformanceTracker()
 
@@ -62,7 +63,7 @@ class HelicopterEffectsMixIn(AdvancedSpringMixIn):
     collective_ft_init: bool = False
     collective_ft_ovd_trim_down = 0
     collective_ft_ovd_trim_up = 0
-    collective_ft_ovd_cp0_y = 4096
+    collective_ft_ovd_cp0_y: float = 1.0
     collective_ft_use_master_buttons: bool = False
     # end of user parameters
     
@@ -257,8 +258,8 @@ class HelicopterEffectsMixIn(AdvancedSpringMixIn):
                      ForceTrimSW    - bool; cockpit force-trim switch state; when False
                                       the spring follows the stick position without locking
             Written: _coll_ft_dt      (float, s; frame delta time)
-                     _coll_ft_step    (float; trim step size in device units/frame)
-                     _coll_ft_trim_pos (int, –4096 to 4096; current trim offset in device units)
+                     _coll_ft_step    (float; normalized trim step per frame)
+                     _coll_ft_trim_pos (float, -1.0 to 1.0; normalized trim offset)
         """
 
         if not self.is_collective():
@@ -291,7 +292,7 @@ class HelicopterEffectsMixIn(AdvancedSpringMixIn):
         if not force_trim_active:
             # Force trim is enabled, but the 'ForceTrimSW' flag is false, just move
             self.spring_y.set_coefficient(self.collective_ft_ovd_tr_damper)
-            self.collective_ft_ovd_cp0_y = round(y * 4096)
+            self.collective_ft_ovd_cp0_y = float(utils.clamp(y, -1.0, 1.0))
             self.spring_y.set_offset(self.collective_ft_ovd_cp0_y)
             spring.setCondition(self.spring_y)
             return
@@ -303,7 +304,7 @@ class HelicopterEffectsMixIn(AdvancedSpringMixIn):
             # return from method so default spring gains do not get applied at the end of the method
             self.spring_y.set_coefficient(self.collective_ft_ovd_tr_damper)
 
-            self.collective_ft_ovd_cp0_y = round(y * 4096)
+            self.collective_ft_ovd_cp0_y = float(utils.clamp(y, -1.0, 1.0))
             self.spring_y.set_offset(self.collective_ft_ovd_cp0_y)
             spring.setCondition(self.spring_y)
             spring.start(override=True)
@@ -312,12 +313,12 @@ class HelicopterEffectsMixIn(AdvancedSpringMixIn):
         elif self.check_button_press(self.collective_ft_ovd_reset, self.collective_ft_use_master_buttons):
             # if trim reset button pressed, set offsets back to 0
             # print("TRIM RESET")
-            self.collective_ft_ovd_cp0_y = 4096
+            self.collective_ft_ovd_cp0_y = 1.0
             self.spring_y.set_offset(self.collective_ft_ovd_cp0_y)
             spring.setCondition(self.spring_y)
 
         # calculate step size based on configured rate and delta time
-        trim_step_size = self.collective_ft_ovd_trim_rate * dt
+        trim_step_size = self.collective_ft_ovd_trim_rate * dt / FFB_UNITS
 
         self.telem_data._coll_ft_step = trim_step_size
 
@@ -325,16 +326,18 @@ class HelicopterEffectsMixIn(AdvancedSpringMixIn):
             # shift offset based on previously calculated step size.  Ensure value does not exceed limits
             # print("TRIM DOWN")
             self.collective_ft_ovd_cp0_y += trim_step_size
-            self.collective_ft_ovd_cp0_y = utils.clamp(self.collective_ft_ovd_cp0_y, -4096, 4096)
-            self.spring_y.set_offset(round(self.collective_ft_ovd_cp0_y))
+            self.collective_ft_ovd_cp0_y = utils.clamp(
+                self.collective_ft_ovd_cp0_y, -1.0, 1.0)
+            self.spring_y.set_offset(self.collective_ft_ovd_cp0_y)
         elif self.check_button_press(self.collective_ft_ovd_trim_up, self.collective_ft_use_master_buttons):
             # shift offset based on previously calculated step size.  Ensure value does not exceed limits
             # print("TRIM UP")
             self.collective_ft_ovd_cp0_y -= trim_step_size
-            self.collective_ft_ovd_cp0_y = utils.clamp(self.collective_ft_ovd_cp0_y, -4096, 4096)
-            self.spring_y.set_offset(round(self.collective_ft_ovd_cp0_y))
+            self.collective_ft_ovd_cp0_y = utils.clamp(
+                self.collective_ft_ovd_cp0_y, -1.0, 1.0)
+            self.spring_y.set_offset(self.collective_ft_ovd_cp0_y)
 
-        self.telem_data._coll_ft_trim_pos = round(self.collective_ft_ovd_cp0_y)
+        self.telem_data._coll_ft_trim_pos = self.collective_ft_ovd_cp0_y
 
         # If trim release is not pressed, set spring gain based on user setting and start spring override
         self.spring_y.set_coefficient(self.collective_ft_ovd_spring_gain)

--- a/telemffb/sim/base/PedalSpringOverrideMixIn.py
+++ b/telemffb/sim/base/PedalSpringOverrideMixIn.py
@@ -28,8 +28,8 @@ class PedalSpringOverrideMixIn(AdvancedSpringMixIn, AircraftParamsMixIn):
     def __init__(self):
         super().__init__()
         self.pedal_trim_reset_complete: bool = False
-        self.cpO_x = 0
-        self.cpO_y = 0
+        self.cpO_x = 0.0
+        self.cpO_y = 0.0
 
     def ac_update_pedal_trim(self, telem_data: BaseTelemetryData):
         """Update the pedal trim effect based on telemetry data and user input.
@@ -63,11 +63,11 @@ class PedalSpringOverrideMixIn(AdvancedSpringMixIn, AircraftParamsMixIn):
         - Reads (phys_x, phys_y) from the device; phys_y is not used.
         - May modify:
           - self.spring_x.set_coefficient(...) (spring stiffness/force coefficient).
-          - self.spring_x.cpOffset (center-point offset for the spring).
-          - self.cpO_x (cached center-point offset, integer scaled).
+          - self.spring_x.set_offset(...) (center-point offset for the spring).
+          - self.cpO_x (cached normalized center-point offset).
           - self.pedal_trim_reset_complete (boolean indicating reset completion).
         - Calls self.check_button_press(...) to detect button events.
-        - Calls self.step_value_over_time("center_x", self.cpO_x, 1000, 0) to smoothly
+        - Calls self.step_value_over_time("center_x", self.cpO_x, 1000, 0.0) to smoothly
           step cpO_x toward zero during a reset.
         Behavior details
         ----------------
@@ -76,23 +76,24 @@ class PedalSpringOverrideMixIn(AdvancedSpringMixIn, AircraftParamsMixIn):
         - If the force-trim button is pressed (or ft_active is False):
           - If self.pedal_ft_damper_enabled, set spring coefficient to
             self.pedal_ft_damper_force; otherwise set coefficient to 0.
-          - Compute self.cpO_x = round(phys_x * 4096) and write it to
-            self.spring_x.cpOffset.
+          - Cache the normalized physical X position in self.cpO_x and apply it
+            through self.spring_x.set_offset().
           - Return True.
         - Else if the trim-reset button is pressed or a previous reset is still in
           progress (not self.pedal_trim_reset_complete):
           - Set spring coefficient to 4096 (maximum/default).
-          - Call self.step_value_over_time("center_x", self.cpO_x, 1000, 0) to update
+          - Call self.step_value_over_time("center_x", self.cpO_x, 1000, 0.0,
+            floatpoint=True) to update
             self.cpO_x toward 0, assign the result to self.cpO_x and
-            self.spring_x.cpOffset.
+            self.spring_x through set_offset().
           - Set self.pedal_trim_reset_complete to True when cpO_x reaches 0; otherwise
             set it to False.
           - Return True.
         - Otherwise return False.
         Notes
         -----
-        - The code uses a 4096 scaling for cpOffset; phys_x is expected to be in the
-          device's normalized range (consult device conventions for sign and range).
+        - Internal center math remains normalized; set_offset() converts once at
+          the device boundary.
         - This method directly mutates hardware-related objects and internal flags;
           call sites should be prepared for those side effects.
         """
@@ -109,17 +110,18 @@ class PedalSpringOverrideMixIn(AdvancedSpringMixIn, AircraftParamsMixIn):
             else:
                 self.spring_x.set_coefficient(0)
 
-            self.cpO_x = round(phys_x * 4096)
-            self.spring_x.cpOffset = self.cpO_x
+            self.cpO_x = float(utils.clamp(phys_x, -1.0, 1.0))
+            self.spring_x.set_offset(self.cpO_x)
             return True
 
         if trim_reset_pressed or not self.pedal_trim_reset_complete:
             self.spring_x.set_coefficient(4096)
-            self.cpO_x = self.step_value_over_time("center_x", self.cpO_x, 1000, 0)
+            self.cpO_x = self.step_value_over_time(
+                "center_x", self.cpO_x, 1000, 0.0, floatpoint=True)
 
-            self.spring_x.cpOffset = self.cpO_x
+            self.spring_x.set_offset(self.cpO_x)
 
-            if self.cpO_x == 0:
+            if self.cpO_x == 0.0:
                 self.pedal_trim_reset_complete = True
             else:
                 self.pedal_trim_reset_complete = False

--- a/telemffb/sim/msfs_xp/HPGHelicopter.py
+++ b/telemffb/sim/msfs_xp/HPGHelicopter.py
@@ -128,7 +128,7 @@ class HPGHelicopter(Helicopter):
         self.phys_x, self.phys_y = self._get_device_axes()
         # Initialise collective spring center from the device's current physical position
         # so the spring does not immediately fight the pilot on startup.
-        self.cpO_y = round(self.phys_y * 4096)
+        self.cpO_y = utils.clamp(self.phys_y, -1, 1)
         self.collective_spring_coeff_y = round(4096 * utils.clamp(self.collective_ap_spring_gain, 0, 1))
         self.hands_on_active = 0
         self.hands_on_x_active = 0
@@ -198,15 +198,12 @@ class HPGHelicopter(Helicopter):
         """
         phys_x, phys_y = self._get_device_axes()
 
-        # Scale normalised axis value to the ±4096 internal FFB range
-        phys_x = round(phys_x * 4096)
-
         ref_x = self.cpO_x
 
-        threshold = 4096 * percent
+        threshold = percent
 
         # Normalised (0–1) distance from the spring center
-        deviation_x = abs(phys_x - ref_x) / 4096
+        deviation_x = abs(phys_x - ref_x)
 
         x_exceeds_threshold = abs(phys_x - ref_x) > threshold
 
@@ -356,26 +353,26 @@ class HPGHelicopter(Helicopter):
                 sx = round(abs(sema_x_avg), 3)
                 sy = round(abs(sema_y_avg), 3)
 
-                self.afcsx_step_size = sx * 0.25
-                self.afcsy_step_size = sy * 0.25
+                self.afcsx_step_size = sx * 0.25 / 4096
+                self.afcsy_step_size = sy * 0.25 / 4096
 
                 ias = telem_data.IAS or 0  # Indicated Airspeed in m/s
 
                 self.afcs_followup_trim_rate = 100
 
-                # Frame-rate-independent follow-up trim rate.  Multiply the target
-                # rate (units/s) by the elapsed frame time (dt) to get a consistent
-                # trim step regardless of loop frequency.  Fractional steps are
-                # accumulated across frames and only applied once they reach a whole
-                # unit — this prevents step-size quantisation at high frame rates.
+                # Frame-rate-independent follow-up trim rate.  The configured rate is
+                # in device units/s, but the accumulator and applied center step stay
+                # normalized.  Preserve the historical whole-device-unit quantization
+                # so the effective trim feel remains unchanged.
                 dt = perftracker.get_time_delta('hpg_perf_tracker')
 
                 telem_data.hpg_perf_tracker = round(dt, 6)
 
-                followup_trim_step_size_raw = self.afcs_followup_trim_rate * dt
+                followup_trim_step_size_raw = self.afcs_followup_trim_rate * dt / 4096
 
                 self.followup_trim_accumulator += followup_trim_step_size_raw
-                followup_trim_step_size = int(self.followup_trim_accumulator)
+                whole_device_steps = int(self.followup_trim_accumulator * 4096)
+                followup_trim_step_size = whole_device_steps / 4096
                 self.followup_trim_accumulator -= followup_trim_step_size
 
                 telem_data.hpg_followup_step_size = followup_trim_step_size
@@ -433,8 +430,8 @@ class HPGHelicopter(Helicopter):
                         self.cpO_y -= followup_trim_step_size
 
             # Apply the updated spring centers to the hardware and start the effect.
-            self.spring_x.cpOffset = round(self.cpO_x)
-            self.spring_y.cpOffset = round(self.cpO_y)
+            self.spring_x.set_offset(self.cpO_x)
+            self.spring_y.set_offset(self.cpO_y)
             self._spring_handle.setCondition(self.spring_x)
             self._spring_handle.setCondition(self.spring_y)
 
@@ -518,7 +515,7 @@ class HPGHelicopter(Helicopter):
                 # current physical position so the spring re-centers there on release.
                 self._simconnect.set_simdatum_to_msfs("L:FFB_FEET_ON_PEDALS", 1, units="number")
                 self.feet_on_active = True
-                self.cpO_x = round(phys_x * 4096)
+                self.cpO_x = utils.clamp(phys_x, -1, 1)
 
 
             else:
@@ -545,10 +542,10 @@ class HPGHelicopter(Helicopter):
 
                 self.spring_x.set_coefficient(self.pedal_spring_coeff_x)
                 if telem_data.get("SimOnGround", 1):
-                    self.cpO_x = 0
+                    self.cpO_x = 0.0
                 else:
                     # print(f"last_colelctive_y={self.last_collective_y}")
-                    self.cpO_x = round(4096 * self.last_pedal_x)
+                    self.cpO_x = utils.clamp(self.last_pedal_x, -1, 1)
 
                 self.spring_x.set_coefficient(self.hpg_pedal_spring_gain, True)
 
@@ -558,7 +555,7 @@ class HPGHelicopter(Helicopter):
                 # self.damper.damper(coef_x=int(4096 * self.pedal_dampening_gain)).start()
                 self._spring_handle.start()
                 logging.debug(f"self.cpO_x:{self.cpO_x}, phys_x:{phys_x}")
-                if self.cpO_x / 4096 - 0.1 < phys_x < self.cpO_x / 4096 + 0.1:
+                if self.cpO_x - 0.1 < phys_x < self.cpO_x + 0.1:
                     # dont start sending position until physical pedals have centered
                     self.pedals_init = 1
                     logging.info("Pedals Initialized")
@@ -572,7 +569,7 @@ class HPGHelicopter(Helicopter):
 
             sx = round(abs(sema_yaw_avg), 3)
 
-            self.afcsx_step_size = sx * 0.5
+            self.afcsx_step_size = sx * 0.5 / 4096
 
             telem_data._sx = sx
             telem_data._afcsx_step_size = self.afcsx_step_size
@@ -586,7 +583,7 @@ class HPGHelicopter(Helicopter):
 
             telem_data._cp0_x = self.cpO_x
 
-            self.spring_x.set_offset(round(self.cpO_x))
+            self.spring_x.set_offset(self.cpO_x)
             if pedal_trim_pressed:
                 # Disable spring while button is held so pilot can freely reposition pedals
                 if self.pedal_ft_damper_enabled:
@@ -629,21 +626,21 @@ class HPGHelicopter(Helicopter):
         The collective physical axis is inverted relative to the FFB range:
 
         =====================  ================  ==========================
-        Condition              ``phys_y``        ``cpO_y`` (FFB units)
+        Condition              ``phys_y``        ``cpO_y`` (normalized)
         =====================  ================  ==========================
-        Full down (minimum)     +1.0              +4096
+        Full down (minimum)     +1.0               +1.0
         Center                   0.0                  0
-        Full up (maximum)       −1.0              −4096
+        Full up (maximum)       −1.0               −1.0
         =====================  ================  ==========================
 
         ``CollectivePos`` from MSFS also follows an inverted convention:
-        0.0 = full down → cpO_y = +4096; 1.0 = full up → cpO_y = −4096.
+        0.0 = full down → cpO_y = +1.0; 1.0 = full up → cpO_y = −1.0.
 
         Initialization handshake
         ------------------------
         On first call (``collective_init == 0``) the spring center is set to:
 
-        - **On ground**: full-down position (``cpO_y = 4096``).
+        - **On ground**: full-down position (``cpO_y = 1.0``).
         - **Air start / new aircraft**: current physical stick position.
         - **Resuming from pause**: last known physical position
           (``last_collective_y``).
@@ -654,7 +651,7 @@ class HPGHelicopter(Helicopter):
         AFCS vertical mode OFF (``afcs_mode == 0``)
         --------------------------------------------
         *Force trim pressed*: Anchors the spring center to the current physical
-        position (``cpO_y = phys_y × 4096``), applies the softer
+        position (``cpO_y = phys_y``), applies the softer
         ``trim_release_spring_gain``, and sends the physical axis position to MSFS
         (``AXIS_COLLECTIVE_SET``).  ``AUTO_THROTTLE_DISCONNECT`` is also sent to
         disengage any active throttle hold.
@@ -713,21 +710,21 @@ class HPGHelicopter(Helicopter):
 
             if telem_data.get("SimOnGround", 1):
                 # Sim is on ground - set init point to full down
-                self.cpO_y = 4096
+                self.cpO_y = 1.0
             elif self.last_collective_y is None:
                 # Air start or new aircraft.  Use current physical position as init point
-                self.cpO_y = round(4096 * phys_y)
+                self.cpO_y = utils.clamp(phys_y, -1, 1)
             else:
                 # set init point to last point before pause
-                self.cpO_y = round(4096 * self.last_collective_y)
+                self.cpO_y = utils.clamp(self.last_collective_y, -1, 1)
 
-            self.spring_y.cpOffset = self.cpO_y
+            self.spring_y.set_offset(self.cpO_y)
 
             self._spring_handle.setCondition(self.spring_y)
 
             self._spring_handle.start(override=True)
 
-            if self.cpO_y/4096 - 0.1 < phys_y < self.cpO_y/4096 + 0.1:
+            if self.cpO_y - 0.1 < phys_y < self.cpO_y + 0.1:
                 # Check if phys y position is within %10 of init point
                 # dont start sending position until physical stick has centered
                 self.collective_init = 1
@@ -748,7 +745,7 @@ class HPGHelicopter(Helicopter):
                 telem_data['_dbg_collective_FT_pressed'] = True
                 # self._ipc_telem['_dbg_collective_FT_pressed'] = True
 
-                self.cpO_y = round(4096*utils.clamp(phys_y, -1, 1))
+                self.cpO_y = utils.clamp(phys_y, -1, 1)
                 self.spring_y.set_offset(self.cpO_y)
 
                 self.spring_y.set_coefficient(self.trim_release_spring_gain, True)
@@ -786,7 +783,7 @@ class HPGHelicopter(Helicopter):
                     # CollectivePos value from the AFCS release frame, causing a noticeable
                     # snap.  Anchoring to phys_y is equivalent to an automatic force-trim
                     # press at the moment of AP disengagement.
-                    self.cpO_y = round(4096 * utils.clamp(phys_y, -1, 1))
+                    self.cpO_y = utils.clamp(phys_y, -1, 1)
                 self.spring_y.set_offset(self.cpO_y)
                 # self.damper.damper(coef_y=0).start()
                 self.spring_y.set_coefficient(self.collective_ap_spring_gain, True)
@@ -802,7 +799,7 @@ class HPGHelicopter(Helicopter):
                 telem_data['_dbg_collective_FT_pressed'] = True
                 # self._ipc_telem['_dbg_collective_FT_pressed'] = True
 
-                self.cpO_y = round(4096*utils.clamp(phys_y, -1, 1))
+                self.cpO_y = utils.clamp(phys_y, -1, 1)
                 # print(self.cpO_y)
                 self.spring_y.set_offset(self.cpO_y)
 
@@ -837,7 +834,7 @@ class HPGHelicopter(Helicopter):
                 telem_data['_dbg_collective_FT_pressed'] = False
                 # self._ipc_telem['_dbg_collective_FT_pressed'] = False
 
-                self.cpO_y = round(utils.scale(collective_pos,(0, 1), (4096, -4096)))
+                self.cpO_y = utils.scale_clamp(collective_pos, (0, 1), (1.0, -1.0))
                 self.spring_y.set_offset(self.cpO_y)
                 # self.damper.damper(coef_y=0).start()
                 self.spring_y.set_coefficient(self.collective_ap_spring_gain, True)

--- a/telemffb/sim/msfs_xp/Helicopter.py
+++ b/telemffb/sim/msfs_xp/Helicopter.py
@@ -83,8 +83,8 @@ class Helicopter(Aircraft, MsfsXpHeliControlsMixIn):
         self.cyclic_spring_init = 0
         self.collective_init = 0
         self.pedals_init = 0
-        self.cpO_x = 0
-        self.cpO_y = 0
+        self.cpO_x = 0.0
+        self.cpO_y = 0.0
 
     @override
     def on_timeout(self):
@@ -123,16 +123,13 @@ class Helicopter(Aircraft, MsfsXpHeliControlsMixIn):
     def check_hands_on(self, percent) -> dict:
         phys_x, phys_y = self._get_device_axes()
 
-        phys_x = round(phys_x * 4096)
-        phys_y = round(phys_y * 4096)
-
         ref_x = self.cpO_x
         ref_y = self.cpO_y
 
-        threshold = 4096 * percent
+        threshold = percent
 
-        deviation_x = abs(phys_x - ref_x) / 4096
-        deviation_y = abs(phys_y - ref_y) / 4096
+        deviation_x = abs(phys_x - ref_x)
+        deviation_y = abs(phys_y - ref_y)
 
         raw_deviation_x = phys_x - ref_x
         raw_deviation_y = phys_y - ref_y
@@ -202,10 +199,10 @@ class Helicopter(Aircraft, MsfsXpHeliControlsMixIn):
 
         self.spring_x.set_coefficient(self.pedal_spring_coeff_x)
         if telem_data.get("SimOnGround", 1):
-            self.cpO_x = 0
+            self.cpO_x = 0.0
             self.last_pos_x_pos = 0
         else:
-            self.cpO_x = round(4096 * self.last_pedal_x)
+            self.cpO_x = self.last_pedal_x
 
         self.spring_x.set_coefficient(self.pedal_spring_gain, True)
         self.spring_x.set_offset(self.cpO_x)
@@ -214,7 +211,7 @@ class Helicopter(Aircraft, MsfsXpHeliControlsMixIn):
 
         logging.debug(f"self.cpO_x:{self.cpO_x}, phys_x:{phys_x}")
         # Gate output until hardware reaches the seeded center point to avoid control jumps.
-        if self.cpO_x / 4096 - 0.1 < phys_x < self.cpO_x / 4096 + 0.1:
+        if self.cpO_x - 0.1 < phys_x < self.cpO_x + 0.1:
             # dont start sending position until physical pedals have centered
             self.pedals_init = 1
             logging.info("Pedals Initialized")
@@ -235,6 +232,38 @@ class Helicopter(Aircraft, MsfsXpHeliControlsMixIn):
 
         self.spring_x.set_coefficient(0)
         self._spring_handle.setCondition(self.spring_x)
+
+    @override
+    def ac_update_pedal_force_trim(self, telem_data: BaseTelemetryData, ft_active=True):
+        """Update MSFS/X-Plane pedal force trim using normalized spring centers."""
+        if not self.is_pedals():
+            return None
+
+        phys_x, _ = self._get_device_axes()
+        force_trim_pressed = self.check_button_press(
+            self.pedal_ft_release_button, self.pedal_ft_use_master_buttons)
+        trim_reset_pressed = self.check_button_press(
+            self.pedal_ft_reset_button, self.pedal_ft_use_master_buttons)
+
+        if force_trim_pressed or not ft_active:
+            if self.pedal_ft_damper_enabled:
+                self.spring_x.set_coefficient(self.pedal_ft_damper_force)
+            else:
+                self.spring_x.set_coefficient(0)
+
+            self.cpO_x = utils.clamp(phys_x, -1, 1)
+            self.spring_x.set_offset(self.cpO_x)
+            return True
+
+        if trim_reset_pressed or not self.pedal_trim_reset_complete:
+            self.spring_x.set_coefficient(4096)
+            self.cpO_x = self.step_value_over_time(
+                "center_x", self.cpO_x, 1000, 0.0, floatpoint=True)
+            self.spring_x.set_offset(self.cpO_x)
+            self.pedal_trim_reset_complete = self.cpO_x == 0.0
+            return True
+
+        return False
 
     def _send_pedal_outputs(self, telem_data: BaseTelemetryData, phys_x: float, x_scale: float, x_var: str, x_range: float):
         if self._use_firmware_axis_backend():
@@ -277,7 +306,7 @@ class Helicopter(Aircraft, MsfsXpHeliControlsMixIn):
         }
 
         self.spring_y.set_coefficient(4096)
-        self.spring_y.cpOffset = 4096
+        self.spring_y.set_offset(1.0)
         self._spring_handle.setCondition(self.spring_y)
         self._spring_handle.start()
 
@@ -285,7 +314,7 @@ class Helicopter(Aircraft, MsfsXpHeliControlsMixIn):
         if 0.9 < phys_y < 1.0:
             self._engage_controls_lock_detents(
                 self.spring_y,
-                spring_offset=4096,
+                spring_offset=1.0,
                 detent_1=detent_1,
                 detent_2=detent_2,
             )
@@ -302,7 +331,7 @@ class Helicopter(Aircraft, MsfsXpHeliControlsMixIn):
 
         if telem_data.get("SimOnGround", 1):
             # aircraft is on ground, so initialize collective to full down
-            self.cpO_y = 4096
+            self.cpO_y = 1.0
             if self._sim_is_msfs():
                 if y_range != 1:
                     self.last_pos_y_pos = -y_range * 1
@@ -310,18 +339,18 @@ class Helicopter(Aircraft, MsfsXpHeliControlsMixIn):
                     self.last_pos_y_pos = 1
         elif self.last_collective_y is None:
             # Air start or new aircraft. Use current physical position as init point
-            self.cpO_y = round(4096 * phys_y)
+            self.cpO_y = utils.clamp(phys_y, -1, 1)
         else:
             # In air, previously paused. Use stored collective position to init point
-            self.cpO_y = round(4096 * self.last_collective_y)
+            self.cpO_y = utils.clamp(self.last_collective_y, -1, 1)
 
         self.spring_y.set_coefficient(4096)
-        self.spring_y.cpOffset = self.cpO_y
+        self.spring_y.set_offset(self.cpO_y)
         self._spring_handle.setCondition(self.spring_y)
         self._spring_handle.start(override=True)
 
         # Gate output until hardware reaches the seeded center point to avoid control jumps.
-        if self.cpO_y / 4096 - 0.1 < phys_y < self.cpO_y / 4096 + 0.1:
+        if self.cpO_y - 0.1 < phys_y < self.cpO_y + 0.1:
             # dont start sending position until physical stick has centered
             self.collective_init = 1
             logging.info("Collective Initialized")
@@ -338,8 +367,8 @@ class Helicopter(Aircraft, MsfsXpHeliControlsMixIn):
             return
 
         self._spring_handle.name = "collective_ap_spring"
-        self.cpO_y = round(4096 * utils.clamp(phys_y, -1, 1))
-        self.spring_y.cpOffset = self.cpO_y
+        self.cpO_y = utils.clamp(phys_y, -1, 1)
+        self.spring_y.set_offset(self.cpO_y)
         self.spring_y.set_coefficient(round(self.collective_spring_coeff_y / 2))
         self._spring_handle.setCondition(self.spring_y)
         self._spring_handle.start(override=True)

--- a/telemffb/sim/msfs_xp/MsfsXpFlightControlsMixIn.py
+++ b/telemffb/sim/msfs_xp/MsfsXpFlightControlsMixIn.py
@@ -504,8 +504,14 @@ class MsfsXpFlightControlsMixIn(MsfsXpSteeringFrictionMixIn, MsfsXpFBWFlightCont
 
         Note: Vso (XPLANE) is fetched but not used in any downstream computation.
         """
-        if self.vne_override:
-            vne = self.vne_override  # user override (m/s); use it instead of sim data
+        if isinstance(self.vne_override, (float, int)) and self.vne_override:
+            # user override (m/s); use it instead of sim data. Guarded by type as
+            # defense-in-depth: a non-numeric value (e.g. a unit label a user typed
+            # directly into the field) must not reach the `vne * ms2kt` math below --
+            # it falls through to the sim-computed Vne instead. The root cause is
+            # fixed upstream in get_aircraft_config, which no longer concatenates a
+            # <unit> onto an empty value (TASK004).
+            vne = self.vne_override
         elif telem_data.src == "XPLANE":
             vne = telem_data.Vne
             if not vne:

--- a/telemffb/sim/msfs_xp/MsfsXpHeliControlsMixIn.py
+++ b/telemffb/sim/msfs_xp/MsfsXpHeliControlsMixIn.py
@@ -65,16 +65,16 @@ class MsfsXpHeliControlsMixIn(MsfsXpFlightControlsMixIn):
             self.last_pos_x_pos = 0
             self.last_pos_y_pos = 0
         else:
-            self.cpO_x = round(self.last_device_x * 4096)
-            self.cpO_y = round(self.last_device_y * 4096)
+            self.cpO_x = utils.clamp(self.last_device_x, -1, 1)
+            self.cpO_y = utils.clamp(self.last_device_y, -1, 1)
 
-        self.spring_x.cpOffset = self.cpO_x
-        self.spring_y.cpOffset = self.cpO_y
+        self.spring_x.set_offset(self.cpO_x)
+        self.spring_y.set_offset(self.cpO_y)
         self._spring_handle.setCondition(self.spring_x)
         self._spring_handle.setCondition(self.spring_y)
         self._spring_handle.start()
-        if (self.cpO_x / 4096 - 0.15 < phys_x < self.cpO_x / 4096 + 0.15) and (
-            self.cpO_y / 4096 - 0.15 < phys_y < self.cpO_y / 4096 + 0.15
+        if (self.cpO_x - 0.15 < phys_x < self.cpO_x + 0.15) and (
+            self.cpO_y - 0.15 < phys_y < self.cpO_y + 0.15
         ):
             self.cyclic_spring_init = 1
             logging.info("Cyclic Spring Initialized")
@@ -92,8 +92,8 @@ class MsfsXpHeliControlsMixIn(MsfsXpFlightControlsMixIn):
             self._trim_reset_in_progress = True
             logging.info("Trim Reset Pressed")
 
-        self.cpO_x = self.step_value_over_time("center_x", self.cpO_x, 500, 0)
-        self.cpO_y = self.step_value_over_time("center_y", self.cpO_y, 500, 0)
+        self.cpO_x = self.step_value_over_time("center_x", self.cpO_x, 500, 0, floatpoint=True)
+        self.cpO_y = self.step_value_over_time("center_y", self.cpO_y, 500, 0, floatpoint=True)
 
         if self.cpO_x == 0 and self.cpO_y == 0:
             self.trim_reset_complete = 1
@@ -109,8 +109,8 @@ class MsfsXpHeliControlsMixIn(MsfsXpFlightControlsMixIn):
         self.spring_x.set_coefficient(self.cyclic_spring_gain)
         self.spring_y.set_coefficient(self.cyclic_spring_gain)
 
-        self.spring_x.set_offset(round(self.cpO_x))
-        self.spring_y.set_offset(round(self.cpO_y))
+        self.spring_x.set_offset(self.cpO_x)
+        self.spring_y.set_offset(self.cpO_y)
 
         if self._sim_is_msfs() and self.force_trim_send_reset:
             self._simconnect.send_event_to_msfs("ROTOR_TRIM_RESET", 0)
@@ -154,8 +154,8 @@ class MsfsXpHeliControlsMixIn(MsfsXpFlightControlsMixIn):
             elif force_trim_pressed:
                 # Force trim button depressed: absorb trim offsets, soften spring, follow stick
                 if self.tr_state_change:
-                    total_x = int(self.cpO_x) + int(self.cyclic_physical_trim_x_offs)
-                    total_y = int(self.cpO_y) + int(self.cyclic_physical_trim_y_offs)
+                    total_x = self.cpO_x + self.cyclic_physical_trim_x_offs
+                    total_y = self.cpO_y + self.cyclic_physical_trim_y_offs
 
                     self.cpO_x = total_x
                     self.cpO_y = total_y
@@ -173,11 +173,11 @@ class MsfsXpHeliControlsMixIn(MsfsXpFlightControlsMixIn):
                 self.spring_x.set_coefficient(gain)
                 self.spring_y.set_coefficient(gain)
 
-                self.cpO_x = round(x * 4096)
-                self.cpO_y = round(y * 4096)
+                self.cpO_x = utils.clamp(x, -1, 1)
+                self.cpO_y = utils.clamp(y, -1, 1)
 
-                self.spring_x.cpOffset = self.cpO_x
-                self.spring_y.cpOffset = self.cpO_y
+                self.spring_x.set_offset(self.cpO_x)
+                self.spring_y.set_offset(self.cpO_y)
 
                 self.cyclic_center = [x, y]
                 self.cyclic_trim_release_active = 1
@@ -187,8 +187,8 @@ class MsfsXpHeliControlsMixIn(MsfsXpFlightControlsMixIn):
                 self.spring_x.set_coefficient(self.cyclic_spring_gain, True)
                 self.spring_y.set_coefficient(self.cyclic_spring_gain, True)
 
-                self.cpO_x = round(x * 4096)
-                self.cpO_y = round(y * 4096)
+                self.cpO_x = utils.clamp(x, -1, 1)
+                self.cpO_y = utils.clamp(y, -1, 1)
                 self.spring_x.set_offset(self.cpO_x)
                 self.spring_y.set_offset(self.cpO_y)
 
@@ -219,11 +219,11 @@ class MsfsXpHeliControlsMixIn(MsfsXpFlightControlsMixIn):
             self.spring_x.set_coefficient(gain)
             self.spring_y.set_coefficient(gain)
 
-            self.cpO_x = round(x * 4096)
-            self.cpO_y = round(y * 4096)
+            self.cpO_x = utils.clamp(x, -1, 1)
+            self.cpO_y = utils.clamp(y, -1, 1)
 
-            self.spring_x.cpOffset = self.cpO_x
-            self.spring_y.cpOffset = self.cpO_y
+            self.spring_x.set_offset(self.cpO_x)
+            self.spring_y.set_offset(self.cpO_y)
 
             self.cyclic_center = [x, y]
 
@@ -340,8 +340,8 @@ class MsfsXpHeliControlsMixIn(MsfsXpFlightControlsMixIn):
                 self.spring_x.set_coefficient(self.cyclic_spring_gain)
                 self.spring_y.set_coefficient(self.cyclic_spring_gain)
 
-            self.spring_x.set_offset(int(self.cpO_x) + self.cyclic_physical_trim_x_offs)
-            self.spring_y.set_offset(int(self.cpO_y) + self.cyclic_physical_trim_y_offs)
+            self.spring_x.set_offset(self.cpO_x + self.cyclic_physical_trim_x_offs)
+            self.spring_y.set_offset(self.cpO_y + self.cyclic_physical_trim_y_offs)
             self._spring_handle.setCondition(self.spring_x)
             self._spring_handle.setCondition(self.spring_y)
             if self.spring_mode_is(SpringModeEnum.FORCETRIM) and force_trim_active:
@@ -379,8 +379,8 @@ class MsfsXpHeliControlsMixIn(MsfsXpFlightControlsMixIn):
 
         # print(f"x:{cyclic_x_trim}, y:{cyclic_y_trim}")
 
-        self.cyclic_physical_trim_x_offs = round(cyclic_x_trim * 4096)
-        self.cyclic_physical_trim_y_offs = round(cyclic_y_trim * 4096)
+        self.cyclic_physical_trim_x_offs = utils.clamp(cyclic_x_trim, -1, 1)
+        self.cyclic_physical_trim_y_offs = utils.clamp(cyclic_y_trim, -1, 1)
         self.cyclic_virtual_trim_x_offs = cyclic_x_trim - (cyclic_x_trim * self.joystick_trim_follow_gain_virtual_x)
         self.cyclic_virtual_trim_y_offs = cyclic_y_trim - (cyclic_y_trim * self.joystick_trim_follow_gain_virtual_y)
 

--- a/telemffb/sim/msfs_xp/MsfsXpSimConnectMixIn.py
+++ b/telemffb/sim/msfs_xp/MsfsXpSimConnectMixIn.py
@@ -99,6 +99,24 @@ class MsfsXpSimConnectMixIn(AircraftEffectUtilsBase):
         # nothing sent yet, so the plugin's echoed state is trusted at once.
         self.__xplane_override_sent_at = float("-inf")
 
+    def __del__(self):
+        # Close the lazily-created X-Plane UDP socket. An aircraft instance
+        # is dropped by TelemManager simply clearing its reference (sim exit,
+        # aircraft switch) or by the garbage collector (tests, interpreter
+        # shutdown) with no explicit close hook, so without this the socket
+        # is only released by finalization, which raises a ResourceWarning
+        # ("unclosed <socket>") that surfaces as a spurious failure in
+        # whichever test's window the GC happens to run.
+        sock = getattr(self, "_socket", None)
+        if sock is not None:
+            try:
+                sock.close()
+            except Exception:
+                # __del__ can run during interpreter shutdown, when the socket
+                # module is already being torn down; never let cleanup raise.
+                pass
+            self._socket = None
+
     @property
     def joystick_trim_follow_curve_y(self) -> Optional[str]:
         return self._trim_curve_y_json

--- a/telemffb/sim/msfs_xp/MsfsXpTrimwheelMixIn.py
+++ b/telemffb/sim/msfs_xp/MsfsXpTrimwheelMixIn.py
@@ -125,20 +125,20 @@ class MsfsXpTrimwheelMixIn(MsfsXpFlightControlsMixIn):
             if self.last_trimwheel_y is None:
                 # Air start or new aircraft.  Use sim defined trim setpoint as init point
                 trimwheel_pos = telem_data.ElevTrimPct
-                self.cpO_y = round(4096 * trimwheel_pos)
+                self.cpO_y = utils.clamp(trimwheel_pos, -1, 1)
             else:
                 # In air, previously paused.  Use stored position to init point
-                self.cpO_y = round(4096 * self.last_trimwheel_y)
+                self.cpO_y = utils.clamp(self.last_trimwheel_y, -1, 1)
 
             self.spring_y.set_coefficient(1.0)
 
-            self.spring_y.cpOffset = self.cpO_y
+            self.spring_y.set_offset(self.cpO_y)
 
             self._spring_handle.setCondition(self.spring_y)
             # self.damper.damper(coef_y=int(4096*self.trimwheel_dampening_gain)).start()
             self._spring_handle.start(override=True)
             # print(f"self.cpO_y:{self.cpO_y}, phys_y:{phys_y}")
-            if self.cpO_y / 4096 - 0.1 < phys_y < self.cpO_y / 4096 + 0.1:
+            if self.cpO_y - 0.1 < phys_y < self.cpO_y + 0.1:
                 # dont start sending position until physical stick has centered
                 self.trimwheel_init = 1
                 logging.info("Trim Wheel Initialized")
@@ -156,7 +156,7 @@ class MsfsXpTrimwheelMixIn(MsfsXpFlightControlsMixIn):
             spring_pos = trimwheel_pos
             if hold and self._tw_hold_pos is not None:
                 spring_pos = self._tw_hold_pos
-            self.cpO_y = round(utils.scale(spring_pos, (-1, 1), (-4096, 4096)))
+            self.cpO_y = utils.clamp(spring_pos, -1, 1)
             telem_data._tw_cpO_y = spring_pos
             self.spring_y.set_offset(spring_pos)
 

--- a/telemffb/sim/msfs_xp/SASHelicopter.py
+++ b/telemffb/sim/msfs_xp/SASHelicopter.py
@@ -46,7 +46,7 @@ class SASHelicopter(Helicopter):
         super().__init__(name, **kwargs)
         
         self.phys_x, self.phys_y = self._get_device_axes()
-        self.cpO_y = round(self.phys_y * 4096)
+        self.cpO_y = self.phys_y
 
 
     def on_telemetry(self, telem_data: BaseTelemetryData):
@@ -80,8 +80,8 @@ class SASHelicopter(Helicopter):
                 sx = round(abs(sema_x_avg), 3)
                 sy = round(abs(sema_y_avg), 3)
 
-                self.afcsx_step_size = sx * 0.1
-                self.afcsy_step_size = sy * 0.3
+                self.afcsx_step_size = sx * 0.1 / 4096
+                self.afcsy_step_size = sy * 0.3 / 4096
 
                 if not (self.hands_on_x_active or self.hands_on_active):
                     if sema_x_avg > 0:
@@ -95,8 +95,8 @@ class SASHelicopter(Helicopter):
                     elif sema_y_avg < 0:
                         self.cpO_y += self.afcsy_step_size
 
-            self.spring_x.cpOffset = round(self.cpO_x)
-            self.spring_y.cpOffset = round(self.cpO_y)
+            self.spring_x.set_offset(self.cpO_x)
+            self.spring_y.set_offset(self.cpO_y)
             self._spring_handle.setCondition(self.spring_x)
             self._spring_handle.setCondition(self.spring_y)
 

--- a/telemffb/sim/msfs_xp/TrimCalibrator.py
+++ b/telemffb/sim/msfs_xp/TrimCalibrator.py
@@ -413,11 +413,10 @@ class TrimCalibrator:
 
     HOLD_SPRING_COEFF = 1.0      # firm centered spring to keep hands-off stick put
     TRIM_AXIS_RANGE = 16383      # AXIS_ELEV_TRIM_SET: -16383..16384
-    CPOFFSET_RANGE = conversions.FFB_UNITS  # spring cpOffset units per full axis deflection
-    HOLD_WALK_RATE = 3000        # cpOffset units/s for repositioning the parked
-                                 # stick at handback — an instant center set under
-                                 # the firm spring snaps the stick hard enough to
-                                 # whack a hand resting near the controls
+    HOLD_WALK_RATE = 3000 / conversions.FFB_UNITS  # normalized units/s for
+                                 # repositioning the parked stick at handback — an
+                                 # instant center set under the firm spring snaps the
+                                 # stick hard enough to whack a nearby hand
     HOLD_WALK_GRACE_S = 2.0      # release proceeds at most this long after the
                                  # phase would otherwise end, walk done or not
 
@@ -2489,11 +2488,12 @@ class TrimCalibrator:
         tx, ty = targets
         nx = x + clamp(tx - x, -step, step)
         ny = y + clamp(ty - y, -step, step)
-        self._hold_offs = (int(round(nx)), int(round(ny)))
-        return abs(tx - nx) < 1.0 and abs(ty - ny) < 1.0
+        self._hold_offs = (nx, ny)
+        tolerance = 1 / conversions.FFB_UNITS
+        return abs(tx - nx) < tolerance and abs(ty - ny) < tolerance
 
     def _release_hold_targets(self, telem_data):
-        """Stick position (cpOffset units, both axes) at which the normal
+        """Normalized stick position (both axes) at which the normal
         flight-controls path's first frame delivers exactly what the engine
         is delivering now — release continuity. Mirrors the runtime's
         trim-following offset math (calibrated curve or legacy static gain)."""
@@ -2515,7 +2515,7 @@ class TrimCalibrator:
                 x = clamp(x + clamp(a * p_x, -1, 1) * (1 - v_x), -1, 1)
         except Exception as e:  # continuity is comfort; never break teardown
             logger.debug(f"release-continuity targets fell back to raw u: {e}")
-        return int(x * self.CPOFFSET_RANGE), int(y * self.CPOFFSET_RANGE)
+        return round(x, 6), round(y, 6)
 
     @staticmethod
     def _fit(samples):
@@ -2743,15 +2743,16 @@ class TrimCalibrator:
                 # engagement and a snap across the gap when they let go.
                 try:
                     px, py = self.ac._get_device_raw_axes()
-                    self._hold_offs = (int(clamp(px, -1, 1) * self.CPOFFSET_RANGE),
-                                       int(clamp(py, -1, 1) * self.CPOFFSET_RANGE))
+                    self._hold_offs = (clamp(px, -1, 1), clamp(py, -1, 1))
                 except Exception:
-                    self._hold_offs = (int(self.ac.spring_x.cpOffset),
-                                       int(self.ac.spring_y.cpOffset))
+                    self._hold_offs = (
+                        self.ac.spring_x.cpOffset / conversions.FFB_UNITS,
+                        self.ac.spring_y.cpOffset / conversions.FFB_UNITS,
+                    )
                 logger.info(f"Holding stick at spring offsets "
                             f"x={self._hold_offs[0]}, y={self._hold_offs[1]}")
-            self.ac.spring_x.cpOffset = self._hold_offs[0]
-            self.ac.spring_y.cpOffset = self._hold_offs[1]
+            self.ac.spring_x.set_offset(self._hold_offs[0])
+            self.ac.spring_y.set_offset(self._hold_offs[1])
             self.ac.spring_x.set_coefficient(self.HOLD_SPRING_COEFF)
             self.ac.spring_y.set_coefficient(self.HOLD_SPRING_COEFF)
             self.ac._spring_handle.name = "trim_cal_spring"

--- a/telemffb/sim/msfs_xp/XAW109Helicopter.py
+++ b/telemffb/sim/msfs_xp/XAW109Helicopter.py
@@ -58,7 +58,7 @@ class XAW109Helicopter(Helicopter):
         super().__init__(name, **kwargs)
 
         self.phys_x, self.phys_y = self._get_device_axes()
-        self.cpO_y = round(self.phys_y * 4096)
+        self.cpO_y = utils.clamp(self.phys_y, -1, 1)
 
 
     def on_telemetry(self, telem_data: BaseTelemetryData):
@@ -82,15 +82,15 @@ class XAW109Helicopter(Helicopter):
 
             # self.cpO_x += x_rate
             # self.cpO_y += y_rate
-            self.afcsx_step_size = x_rate * self.afcs_motion_rate
-            self.afcsy_step_size = y_rate * self.afcs_motion_rate
+            self.afcsx_step_size = x_rate * self.afcs_motion_rate / 4096
+            self.afcsy_step_size = y_rate * self.afcs_motion_rate / 4096
 
             self.cpO_x += self.afcsx_step_size
             self.cpO_y += self.afcsy_step_size
 
 
-            self.spring_x.cpOffset = round(self.cpO_x)
-            self.spring_y.cpOffset = round(self.cpO_y)
+            self.spring_x.set_offset(self.cpO_x)
+            self.spring_y.set_offset(self.cpO_y)
             self._spring_handle.setCondition(self.spring_x)
             self._spring_handle.setCondition(self.spring_y)
 
@@ -146,16 +146,16 @@ class XAW109Helicopter(Helicopter):
 
             self.spring_x.negativeCoefficient = self.spring_x.positiveCoefficient = self.pedal_spring_coeff_x
             if telem_data.get("SimOnGround", 1):
-                self.cpO_x = 0
+                self.cpO_x = 0.0
             else:
-                self.cpO_x = round(4096 * self.last_pedal_x)
+                self.cpO_x = utils.clamp(self.last_pedal_x, -1, 1)
             self.spring_x.positiveCoefficient = self.spring_x.negativeCoefficient = round(
                 4096 * utils.clamp(self.pedal_spring_gain, 0, 1))
 
-            self.spring_x.cpOffset = self.cpO_x
+            self.spring_x.set_offset(self.cpO_x)
             self._spring_handle.setCondition(self.spring_x)
             self._spring_handle.start()
-            if self.cpO_x / 4096 - 0.1 < phys_x < self.cpO_x / 4096 + 0.1:
+            if self.cpO_x - 0.1 < phys_x < self.cpO_x + 0.1:
                 # dont start sending position until physical pedals have centered
                 self.pedals_init = 1
             else:
@@ -168,8 +168,8 @@ class XAW109Helicopter(Helicopter):
                 force = int(self.pedal_ft_damper_force * 4096)
             else:
                 force = 0
-            self.cpO_x = round(4096 * utils.clamp(phys_x, -1, 1))
-            self.spring_x.cpOffset = self.cpO_x
+            self.cpO_x = utils.clamp(phys_x, -1, 1)
+            self.spring_x.set_offset(self.cpO_x)
             self.spring_x.negativeCoefficient = self.spring_x.positiveCoefficient = force
             self._spring_handle.setCondition(self.spring_x)
             self._spring_handle.start()
@@ -209,23 +209,23 @@ class XAW109Helicopter(Helicopter):
             if rate_cmd:
                 # Authoritative upper-mode servo command: bang-bang +/-1,
                 # scaled exactly like the cyclic follow.
-                step = rate_cmd * self.afcs_motion_rate
+                step = rate_cmd * self.afcs_motion_rate / 4096
             elif active:
                 ias_kt = (telem_data.IAS or 0) * ms2kt
                 ias_gain = utils.scale_clamp(
                     ias_kt, self.PEDAL_AFCS_IAS_FADE_KT, self.PEDAL_AFCS_IAS_GAIN)
                 mag = utils.clamp(abs(s) / enter, 0.0, self.PEDAL_AFCS_PROP_CAP)
                 step = math.copysign(
-                    self.afcs_motion_rate * mag * ias_gain, s)
+                    self.afcs_motion_rate * mag * ias_gain / 4096, s)
 
-            self.cpO_x = utils.clamp(self.cpO_x + step, -4096, 4096)
+            self.cpO_x = utils.clamp(self.cpO_x + step, -1, 1)
             telem_data._telemffb_moving_rud = bool(step)
             telem_data._pedal_afcs_demand = s
             telem_data._pedal_afcs_active = active
 
             force = round(4096 * self.pedal_spring_gain)
-            self.spring_x.cpOffset = round(self.cpO_x)
-            self.spring_y.cpOffset = 0
+            self.spring_x.set_offset(self.cpO_x)
+            self.spring_y.set_offset(0.0)
             self.spring_y.negativeCoefficient = self.spring_y.positiveCoefficient = 0
             self.spring_x.negativeCoefficient = self.spring_x.positiveCoefficient = int(self.pedal_spring_gain * force)
             self._spring_handle.setCondition(self.spring_x)
@@ -248,7 +248,7 @@ class XAW109Helicopter(Helicopter):
         collective_v_mode = telem_data.AW109_collective_mode or 0
 
         collective_afcs_pos = telem_data.AW109_collective_ratio or 0
-        axis_afcs_pos = utils.scale_clamp(collective_afcs_pos, (0,1), (4096, -4096), return_int=True)
+        axis_afcs_pos = utils.scale_clamp(collective_afcs_pos, (0, 1), (1.0, -1.0))
 
         phys_x, phys_y = self._get_device_axes()
         telem_data.phys_y = phys_y
@@ -259,15 +259,15 @@ class XAW109Helicopter(Helicopter):
 
             if telem_data.get("SimOnGround", 1):
                 # Sim is on ground - set init point to full down
-                self.cpO_y = 4096
+                self.cpO_y = 1.0
             elif self.last_collective_y is None:
                 # Air start or new aircraft.  Use current physical position as init point
-                self.cpO_y = round(4096 * phys_y)
+                self.cpO_y = utils.clamp(phys_y, -1, 1)
             else:
                 # set init point to last point before pause
-                self.cpO_y = round(4096 * self.last_collective_y)
+                self.cpO_y = utils.clamp(self.last_collective_y, -1, 1)
 
-            self.spring_y.cpOffset = self.cpO_y
+            self.spring_y.set_offset(self.cpO_y)
 
             self._spring_handle.setCondition(self.spring_y)
 
@@ -277,7 +277,7 @@ class XAW109Helicopter(Helicopter):
             # the spring and the lever stalls short of the init gate)
             self._spring_handle.start(override=True)
 
-            if self.cpO_y / 4096 - 0.1 < phys_y < self.cpO_y / 4096 + 0.1:
+            if self.cpO_y - 0.1 < phys_y < self.cpO_y + 0.1:
                 # Check if phys y position is within %10 of init point
                 # dont start sending position until physical stick has centered
                 self.collective_init = 1
@@ -289,9 +289,9 @@ class XAW109Helicopter(Helicopter):
 
         if collective_ft_released:
 
-            self.cpO_y = round(4096 * utils.clamp(phys_y, -1, 1))
+            self.cpO_y = utils.clamp(phys_y, -1, 1)
             # print(self.cpO_y)
-            self.spring_y.cpOffset = self.cpO_y
+            self.spring_y.set_offset(self.cpO_y)
 
             # self.damper.damper(coef_y=0).start()
             self.spring_y.negativeCoefficient = self.spring_y.positiveCoefficient = int(
@@ -303,7 +303,7 @@ class XAW109Helicopter(Helicopter):
             if collective_v_mode:
                 self.cpO_y = axis_afcs_pos
             # self.cpO_y -= self.afcsy_step_size
-            self.spring_y.cpOffset = round(self.cpO_y)
+            self.spring_y.set_offset(self.cpO_y)
 
             # self.damper.damper(coef_y=0).start()
             self.spring_y.negativeCoefficient = self.spring_y.positiveCoefficient = 4096

--- a/telemffb/telem/TelemManager.py
+++ b/telemffb/telem/TelemManager.py
@@ -217,10 +217,13 @@ class TelemManager(QObject, threading.Thread):
                 u = setting['unit']
                 if v is None:
                     v = '0'
-                if u is not None:
-                    vu = v + u
-                else:
-                    vu = v
+                # Attach the unit only when there is a value to attach it to. An
+                # empty value (e.g. the shipped default for vne_override, which is
+                # the documented "leave blank to use sim data") must stay empty:
+                # concatenating a <unit> to it produced a bare unit string ("kt")
+                # that to_number() returns verbatim, so the value reached aircraft
+                # code as a string and crashed downstream arithmetic (`vne * ms2kt`).
+                vu = (v + u) if v else v
                 if setting['value'] != '-':
                     params[k] = vu
                     logging.debug(f"Got from Settings Manager: {k} : {vu}")

--- a/tests/framework/base.py
+++ b/tests/framework/base.py
@@ -96,12 +96,16 @@ class MockFFBDevice:
     def supports_axis_override(self):
         import telemffb.globals as G
         import re
-        if G.device_firmware_version is None:
+        ver_str = getattr(G, "device_firmware_version", None)
+        if ver_str is None:
             return False
         # v1.0.18b14 -> 101814, v1.0.18 -> 1018
         # Use numeric comparison to ensure beta versions (>1018) pass
-        ver = int(re.sub(r'\D', '', G.device_firmware_version))
-        return ver > 1018
+        # Non-numeric placeholders (e.g. "Unknown") yield no digits -> unsupported.
+        digits = re.sub(r'\D', '', str(ver_str))
+        if not digits:
+            return False
+        return int(digits) > 1018
 
     def send_axis_override(self, x_mode=0, x_value=0, y_mode=0, y_value=0, watchdog_ms=1000):
         self.axis_override_commands.append(

--- a/tests/test_aircraft_config_unit_concat.py
+++ b/tests/test_aircraft_config_unit_concat.py
@@ -1,0 +1,113 @@
+"""Unit tests for ``TelemManager.get_aircraft_config`` value+unit handling.
+
+Regression test for TASK004 (the smitty "no FFB in MSFS" post-mortem).
+
+Root cause: a setting whose resolved value is *empty* (e.g. the shipped default
+for ``vne_override`` -- ``<unit>kt</unit>`` with no ``<value>`` element) was
+concatenated with its unit into a bare unit string (``'' + 'kt' == 'kt'``).
+``utils.to_number('kt')`` cannot parse that and returns it verbatim, so the
+string ``'kt'`` reached aircraft code and crashed downstream arithmetic
+(``vne * ms2kt`` in ``MsfsXpFlightControlsMixIn._calculate_vne_and_gains``)
+every telemetry frame, killing all F FB on both devices.
+
+The fix (TelemManager.get_aircraft_config) only attaches a unit when there is a
+value to attach it to, so an empty value stays empty (falsy) and the documented
+"leave blank to use sim data" behaviour actually works. These tests pin that
+contract and guard the normal numeric / no-unit / None cases.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("PyQt6")
+
+import telemffb.globals as G
+import telemffb.xmlutils as xmlutils
+from telemffb.telem.TelemManager import TelemManager
+
+pytestmark = [
+    pytest.mark.unit,
+    # importing TelemManager pulls in the simconnect package, which leaks an
+    # open FileIO on its scvars.json at interpreter teardown - not ours
+    pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning"),
+]
+
+KT2MS = 0.514444  # mirror of telemffb.util.conversions.kt2ms
+
+
+@pytest.fixture
+def get_config(monkeypatch):
+    """Drive get_aircraft_config with a hand-built resolved settings list.
+
+    Returns a callable: ``get_config(rows)`` where each row is a
+    (name, value, unit) tuple -> returns the sanitized ``params`` dict.
+    """
+    monkeypatch.setattr(G, 'device_type', 'joystick', raising=False)
+    monkeypatch.setattr(xmlutils, 'get_pattern_by_sim_fullname',
+                        lambda sim, full_name: '.*')
+    monkeypatch.setattr(xmlutils, 'get_active_profile_for_model',
+                        lambda sim, cls, model: None)
+    monkeypatch.setattr(G, 'settings_mgr',
+                        SimpleNamespace(update_state_vars=lambda **kw: None),
+                        raising=False)
+
+    def _run(rows, data_source='MSFS'):
+        settings = [{'name': n, 'value': v, 'unit': u} for (n, v, u) in rows]
+
+        def fake_read_single_model(the_sim, aircraft_name, input_modeltype='',
+                                   instance_device='', active_profile=None):
+            return 'Aircraft', '.*', list(settings)
+
+        monkeypatch.setattr(xmlutils, 'read_single_model', fake_read_single_model)
+        mgr = TelemManager.__new__(TelemManager)  # skip QObject __init__
+        params, _ = mgr.get_aircraft_config('TestPlane', data_source)
+        return params
+
+    return _run
+
+
+class TestUnitConcat:
+    def test_empty_value_with_unit_stays_empty(self, get_config):
+        """THE regression: empty value + <unit>kt</unit> must stay '' (not 'kt')."""
+        params = get_config([('vne_override', '', 'kt')])
+        assert params['vne_override'] == ''
+        assert not params['vne_override']  # falsy -> falls through to sim data
+
+    def test_numeric_value_with_unit_still_converts(self, get_config):
+        """Normal case must be unchanged: '72' + 'kt' -> 72 kt in m/s."""
+        params = get_config([('vne_override', '72', 'kt')])
+        assert params['vne_override'] == pytest.approx(72 * KT2MS, abs=1e-3)
+
+    def test_numeric_value_without_unit(self, get_config):
+        """No unit: the raw number is passed straight through (int for whole value)."""
+        params = get_config([('vne_override', '150', '')])
+        assert params['vne_override'] == 150
+
+    def test_float_value_with_unit(self, get_config):
+        """A decimal value keeps its decimal (float path, not int). The m/s
+        factor is 1.0, so the value is preserved as a float."""
+        params = get_config([('vne_override', '37.5', 'm/s')])
+        assert params['vne_override'] == pytest.approx(37.5)
+
+    def test_none_value_becomes_zero(self, get_config):
+        """None value normalises to 0 (pre-existing behaviour, must be preserved)."""
+        params = get_config([('vne_override', None, '')])
+        assert params['vne_override'] == 0
+
+    def test_unsuffixed_settings_unaffected(self, get_config):
+        """A boolean-ish / non-unit setting with an empty value stays empty."""
+        params = get_config([('my_flag', '', '')])
+        assert params['my_flag'] == ''
+
+
+class TestMixedSettingsList:
+    def test_multiple_settings_resolve_independently(self, get_config):
+        """Empty and populated unit-suffixed settings coexist correctly."""
+        params = get_config([
+            ('vne_override', '', 'kt'),
+            ('some_speed', '100', 'mph'),
+            ('plain_number', '5', ''),
+        ])
+        assert params['vne_override'] == ''
+        assert params['some_speed'] == pytest.approx(100 / 2.23693679, abs=1e-2)  # mph->m/s
+        assert params['plain_number'] == 5

--- a/tests/test_helicopter.py
+++ b/tests/test_helicopter.py
@@ -188,8 +188,8 @@ class TestHelicopterCollective(BaseTelemetryEffectTestCase):
         
         instance.msfs_update_collective(telem)
         
-        # Should set cpO_y to full down (4096)
-        assert instance.cpO_y == 4096
+        # Should set normalized cpO_y to full down (+1.0).
+        assert instance.cpO_y == 1.0
     
     def test_collective_initialization_in_air_no_previous(self):
         """Test collective initializes to current position when in air with no previous data."""
@@ -207,7 +207,7 @@ class TestHelicopterCollective(BaseTelemetryEffectTestCase):
         instance.msfs_update_collective(telem)
         
         # Should set cpO_y based on current physical position
-        expected_offset = round(4096 * 0.5)
+        expected_offset = 0.5
         assert instance.cpO_y == expected_offset
     
     def test_collective_initialization_with_previous_position(self):
@@ -224,7 +224,7 @@ class TestHelicopterCollective(BaseTelemetryEffectTestCase):
         instance.msfs_update_collective(telem)
         
         # Should use saved position
-        expected_offset = round(4096 * 0.3)
+        expected_offset = 0.3
         assert instance.cpO_y == expected_offset
     
     def test_collective_waits_for_physical_stick_centering(self):
@@ -430,7 +430,7 @@ class TestHelicopterPedals(BaseTelemetryEffectTestCase):
         instance.msfs_update_pedals(telem)
         
         # Should use saved position
-        expected_offset = round(4096 * 0.4)
+        expected_offset = 0.4
         assert instance.cpO_x == expected_offset
     
     def test_pedals_waits_for_centering(self):
@@ -492,18 +492,22 @@ class TestHelicopterPedals(BaseTelemetryEffectTestCase):
         instance.telemffb_controls_axes = True
         instance.pedals_init = 1
         instance.spring_mode = SpringModeEnum.FORCETRIM
+        instance.pedal_ft_release_button = 1
         
         telem = self._create_heli_telem()
         telem["FFBType"] = "pedals"
         telem["ForceTrimSW"] = True
         self.set_telemetry(instance, telem)
         
-        self.mock_device._input_data.set_axis(x=0.0)
+        self.mock_device._input_data.set_axis(x=0.25)
+        self.mock_device._input_data.press_button(1)
         
         instance.msfs_update_pedals(telem)
         
         # Verify spring was configured (check name)
         assert instance._spring_handle.name == "pedal_spring"
+        assert instance.cpO_x == pytest.approx(0.25)
+        assert instance.spring_x.cpOffset == round(0.25 * 4096)
     
     def test_pedals_custom_force_trim_switch(self):
         """Test pedals with custom force trim switch variable."""
@@ -689,8 +693,8 @@ class TestHelicopterCyclicControls(BaseTelemetryEffectTestCase):
         instance.force_trim_button = 1
         instance.force_trim_reset_button = 2
         instance.cyclic_spring_init = 1
-        instance.cpO_x = 2000
-        instance.cpO_y = 3000
+        instance.cpO_x = 2000 / 4096
+        instance.cpO_y = 3000 / 4096
         
         telem = self._create_heli_telem()
         self.set_telemetry(instance, telem)
@@ -703,8 +707,8 @@ class TestHelicopterCyclicControls(BaseTelemetryEffectTestCase):
         # Should start moving toward center
         assert instance.trim_reset_complete == 0
         # Offsets should be moving toward 0 (first call returns original value)
-        assert abs(instance.cpO_x) <= 2000
-        assert abs(instance.cpO_y) <= 3000
+        assert abs(instance.cpO_x) <= 2000 / 4096
+        assert abs(instance.cpO_y) <= 3000 / 4096
     
     def test_cyclic_sends_position_to_msfs(self):
         """Test cyclic sends position to MSFS."""
@@ -868,8 +872,8 @@ class TestCyclicSubMethods(BaseTelemetryEffectTestCase):
 
     def test_trim_reset_starts_animation(self):
         inst = self._make_instance()
-        inst.cpO_x = 2000
-        inst.cpO_y = 3000
+        inst.cpO_x = 2000 / 4096
+        inst.cpO_y = 3000 / 4096
         inst.cyclic_spring_gain = 4096
 
         inst._handle_cyclic_trim_reset()
@@ -936,10 +940,10 @@ class TestCyclicSubMethods(BaseTelemetryEffectTestCase):
     def test_force_trim_pressed_absorbs_offsets(self):
         inst = self._make_instance()
         inst.cyclic_spring_init = 1
-        inst.cpO_x = 1000
-        inst.cpO_y = 2000
-        inst.cyclic_physical_trim_x_offs = 100
-        inst.cyclic_physical_trim_y_offs = 200
+        inst.cpO_x = 1000 / 4096
+        inst.cpO_y = 2000 / 4096
+        inst.cyclic_physical_trim_x_offs = 100 / 4096
+        inst.cyclic_physical_trim_y_offs = 200 / 4096
         inst.cyclic_virtual_trim_x_offs = 50.0
         inst.cyclic_virtual_trim_y_offs = 60.0
         telem = self._make_telem()
@@ -1666,20 +1670,20 @@ class TestCheckHandsOn(BaseTelemetryEffectTestCase):
 
     def test_hands_on_returns_raw_deviations(self):
         instance = self._make_instance()
-        instance.cpO_x = 1000
-        instance.cpO_y = -500
+        instance.cpO_x = 1000 / 4096
+        instance.cpO_y = -500 / 4096
 
         self.mock_device._input_data.set_axis(x=0.5, y=0.0)
 
         result = instance.check_hands_on(0.01)
 
-        assert result["x_deviation_raw"] == round(0.5 * 4096) - 1000
-        assert result["y_deviation_raw"] == round(0.0 * 4096) - (-500)
+        assert result["x_deviation_raw"] == pytest.approx(0.5 - 1000 / 4096)
+        assert result["y_deviation_raw"] == pytest.approx(500 / 4096)
 
     def test_hands_on_with_offset_reference(self):
         instance = self._make_instance()
-        instance.cpO_x = 2000
-        instance.cpO_y = 2000
+        instance.cpO_x = 2000 / 4096
+        instance.cpO_y = 2000 / 4096
         self.mock_device._input_data.set_axis(x=0.5, y=0.5)
 
         result = instance.check_hands_on(0.1)

--- a/tests/test_helicopter.py
+++ b/tests/test_helicopter.py
@@ -820,8 +820,8 @@ class TestCyclicSubMethods(BaseTelemetryEffectTestCase):
 
         result = inst._initialize_cyclic_if_needed(telem)
 
-        assert inst.cpO_x == round(0.25 * 4096)
-        assert inst.cpO_y == round(-0.3 * 4096)
+        assert inst.cpO_x == 0.25
+        assert inst.cpO_y == -0.3
         # stick is at target → completes
         assert result is False
         assert inst.cyclic_spring_init == 1
@@ -973,8 +973,8 @@ class TestCyclicSubMethods(BaseTelemetryEffectTestCase):
         assert result is False
         assert inst.cyclic_trim_release_active == 0
         assert inst.cyclic_center == [0.4, 0.5]
-        assert inst.cpO_x == round(0.4 * 4096)
-        assert inst.cpO_y == round(0.5 * 4096)
+        assert inst.cpO_x == 0.4
+        assert inst.cpO_y == 0.5
 
     def test_force_trim_idle_sets_initial_coefficient(self):
         inst = self._make_instance()
@@ -1005,8 +1005,8 @@ class TestCyclicSubMethods(BaseTelemetryEffectTestCase):
 
         assert result is False
         assert inst.ft_was_inactive is True
-        assert inst.cpO_x == round(0.3 * 4096)
-        assert inst.cpO_y == round(-0.2 * 4096)
+        assert inst.cpO_x == 0.3
+        assert inst.cpO_y == -0.2
 
     def test_force_trim_non_forcetrim_mode_zeroes_spring(self):
         inst = self._make_instance()

--- a/tests/test_hpg_helicopter.py
+++ b/tests/test_hpg_helicopter.py
@@ -1,15 +1,11 @@
 """Characterization tests for HPGHelicopter cyclic SEMA follow-up trim.
 
-These tests pin the observable behavior of the HPG cyclic path BEFORE the
-cpO_* unit normalization (TASK002): the spring center (cpO_x/cpO_y) is
-expressed in DEVICE units (0..4096) and written raw to spring.cpOffset.
+These tests pin the observable behavior of the HPG cyclic path after the
+TASK002 unit normalization: the spring center (cpO_x/cpO_y) is expressed as
+a normalized float while ``set_offset()`` performs the device-unit conversion.
 
 The device-unit ``spring_x/y.cpOffset`` assertions are the invariant
-regression guard: after TASK002 normalizes cpO_* to -1..1, the hardware must
-still receive the same device-unit offsets (via the type-sniffing
-``set_offset()``), so these assertions must keep passing unchanged. Only the
-internal ``cpO_*`` assertions are expected to be rewritten in normalized
-units.
+regression guard: the hardware must still receive the same device-unit offsets.
 """
 import pytest
 
@@ -65,30 +61,30 @@ class TestHPGCyclicSemaFollow(BaseTelemetryEffectTestCase):
     def test_sema_positive_drives_cpO_x_negative(self):
         ac = self._inst()
         # First rolling-average call returns the value itself: sema_x=20
-        # -> afcsx_step_size = 20 * 0.25 = 5 device units.
+        # -> historical 5-device-unit step, represented as 5/4096 internally.
         ac.msfs_update_heli_controls(self._telem(hpgSEMAx=20, hpgSEMAy=0))
-        assert ac.afcsx_step_size == pytest.approx(5.0)
-        assert ac.cpO_x == pytest.approx(-5.0)
+        assert ac.afcsx_step_size == pytest.approx(5 / 4096)
+        assert ac.cpO_x == pytest.approx(-5 / 4096)
         assert ac.cpO_y == 0
 
     def test_sema_negative_drives_cpO_x_positive(self):
         ac = self._inst()
         ac.msfs_update_heli_controls(self._telem(hpgSEMAx=-20, hpgSEMAy=0))
-        assert ac.cpO_x == pytest.approx(5.0)
+        assert ac.cpO_x == pytest.approx(5 / 4096)
 
     def test_sema_y_drives_cpO_y(self):
         ac = self._inst()
         ac.msfs_update_heli_controls(self._telem(hpgSEMAx=0, hpgSEMAy=10))
-        assert ac.afcsy_step_size == pytest.approx(2.5)
-        assert ac.cpO_y == pytest.approx(-2.5)
+        assert ac.afcsy_step_size == pytest.approx(2.5 / 4096)
+        assert ac.cpO_y == pytest.approx(-2.5 / 4096)
 
     def test_spring_cpOffset_tracks_cpO_in_device_units(self):
         # THE invariant guard: the hardware must see the same device-unit
         # offset before and after the TASK002 normalization.
         ac = self._inst()
         ac.msfs_update_heli_controls(self._telem(hpgSEMAx=20, hpgSEMAy=10))
-        assert ac.spring_x.cpOffset == round(ac.cpO_x)
-        assert ac.spring_y.cpOffset == round(ac.cpO_y)
+        assert ac.spring_x.cpOffset == round(ac.cpO_x * 4096)
+        assert ac.spring_y.cpOffset == round(ac.cpO_y * 4096)
         assert ac.spring_x.cpOffset == -5
         assert ac.spring_y.cpOffset == -2
 
@@ -149,7 +145,7 @@ class TestHPGFollowupTrim(BaseTelemetryEffectTestCase):
             hpg_module.perftracker, "get_time_delta", lambda name: 0.01)
         ac = self._inst()
         ac.msfs_update_heli_controls(self._telem(hpgSEMAx=0, hpgSEMAy=0))
-        assert ac.cpO_x == pytest.approx(1.0)
+        assert ac.cpO_x == pytest.approx(1 / 4096)
         # accumulator keeps the fractional remainder (0.01*100 = 1 exactly)
         assert ac.followup_trim_accumulator == pytest.approx(0.0, abs=1e-9)
 
@@ -161,7 +157,7 @@ class TestHPGFollowupTrim(BaseTelemetryEffectTestCase):
         ac = self._inst()
         ac.msfs_update_heli_controls(self._telem(hpgSEMAx=0, hpgSEMAy=0))
         ac.msfs_update_heli_controls(self._telem(hpgSEMAx=0, hpgSEMAy=0))
-        assert ac.cpO_x == pytest.approx(1.0)
+        assert ac.cpO_x == pytest.approx(1 / 4096)
 
     def test_followup_accumulator_carries_fraction(self, monkeypatch):
         # dt = 15 ms -> 1.5 units: 1 whole unit applied, 0.5 carried.
@@ -169,11 +165,11 @@ class TestHPGFollowupTrim(BaseTelemetryEffectTestCase):
             hpg_module.perftracker, "get_time_delta", lambda name: 0.015)
         ac = self._inst()
         ac.msfs_update_heli_controls(self._telem(hpgSEMAx=0, hpgSEMAy=0))
-        assert ac.cpO_x == pytest.approx(1.0)
-        assert ac.followup_trim_accumulator == pytest.approx(0.5, abs=1e-9)
+        assert ac.cpO_x == pytest.approx(1 / 4096)
+        assert ac.followup_trim_accumulator == pytest.approx(0.5 / 4096, abs=1e-9)
         # Next frame adds another 1.5 -> 0.5+1.5 = 2.0 -> 2 units applied.
         ac.msfs_update_heli_controls(self._telem(hpgSEMAx=0, hpgSEMAy=0))
-        assert ac.cpO_x == pytest.approx(3.0)
+        assert ac.cpO_x == pytest.approx(3 / 4096)
         assert ac.followup_trim_accumulator == pytest.approx(0.0, abs=1e-9)
 
     def test_followup_trim_disabled_on_ground(self, monkeypatch):
@@ -198,8 +194,8 @@ class TestHPGFollowupTrim(BaseTelemetryEffectTestCase):
         ac = self._inst()
         ac.msfs_update_heli_controls(self._telem(hpgSEMAx=0, hpgSEMAy=0))
         # 0.05 s * 100 units/s = 5 device units
-        assert ac.cpO_x == pytest.approx(5.0)
-        assert ac.spring_x.cpOffset == round(ac.cpO_x)
+        assert ac.cpO_x == pytest.approx(5 / 4096)
+        assert ac.spring_x.cpOffset == round(ac.cpO_x * 4096)
         assert ac.spring_x.cpOffset == 5
 
 
@@ -233,20 +229,19 @@ class TestHPGPedalSemaFollow(BaseTelemetryEffectTestCase):
 
     def test_yaw_sema_drives_cpO_x(self):
         ac = self._inst()
-        # sema_yaw=10 -> afcsx_step_size = 10 * 0.5 = 5 device units
+        # sema_yaw=10 -> historical 5-device-unit step = 5/4096 normalized
         telem = self._telem(hpgSEMAyaw=10)
         ac.msfs_update_pedals(telem)
-        assert ac.afcsx_step_size == pytest.approx(5.0)
-        assert ac.cpO_x == pytest.approx(-5.0)
+        assert ac.afcsx_step_size == pytest.approx(5 / 4096)
+        assert ac.cpO_x == pytest.approx(-5 / 4096)
         # telemetry exposure: _cp0_x mirrors the pedal spring center
         assert getattr(telem, "_cp0_x") == pytest.approx(ac.cpO_x)
 
     def test_pedal_spring_offset_uses_set_offset(self):
-        # The pedal path already routes through set_offset(); with device-unit
-        # cpO_x the mock's magnitude heuristic passes it through unchanged.
+        # The normalized center is converted exactly once by set_offset().
         ac = self._inst()
         ac.msfs_update_pedals(self._telem(hpgSEMAyaw=10))
-        assert ac.spring_x.cpOffset == round(ac.cpO_x)
+        assert ac.spring_x.cpOffset == round(ac.cpO_x * 4096)
         assert ac.spring_x.cpOffset == -5
 
     def test_feet_on_pedals_freezes_sema_follow(self):

--- a/tests/test_hpg_helicopter.py
+++ b/tests/test_hpg_helicopter.py
@@ -1,0 +1,259 @@
+"""Characterization tests for HPGHelicopter cyclic SEMA follow-up trim.
+
+These tests pin the observable behavior of the HPG cyclic path BEFORE the
+cpO_* unit normalization (TASK002): the spring center (cpO_x/cpO_y) is
+expressed in DEVICE units (0..4096) and written raw to spring.cpOffset.
+
+The device-unit ``spring_x/y.cpOffset`` assertions are the invariant
+regression guard: after TASK002 normalizes cpO_* to -1..1, the hardware must
+still receive the same device-unit offsets (via the type-sniffing
+``set_offset()``), so these assertions must keep passing unchanged. Only the
+internal ``cpO_*`` assertions are expected to be rewritten in normalized
+units.
+"""
+import pytest
+
+import telemffb.globals as G
+import telemffb.sim.msfs_xp.HPGHelicopter as hpg_module
+from tests.framework.base import BaseTelemetryEffectTestCase
+from tests.framework.utils import TelemetryDataBuilder
+from telemffb.sim.msfs_xp.HPGHelicopter import HPGHelicopter
+
+
+@pytest.fixture(autouse=True)
+def _firmware_version():
+    # _get_device_raw_axes() consults the firmware version via the mock device
+    G.device_firmware_version = "1.0.18"
+    yield
+    G.device_firmware_version = None
+
+
+@pytest.mark.unit
+@pytest.mark.msfs
+@pytest.mark.helicopter
+class TestHPGCyclicSemaFollow(BaseTelemetryEffectTestCase):
+    """SEMA-driven spring-center follow (hands off the cyclic)."""
+
+    def _inst(self):
+        ac = self.create_aircraft_instance(
+            HPGHelicopter, name="HPG H145",
+            _test_sim_is_msfs=True, _test_device_type="joystick")
+        # BASIC spring mode: the parent cyclic path leaves cpO_* untouched
+        # (coefficients 0), so the HPG SEMA logic is the only mutator.
+        from telemffb.SettingsManager import SpringModeEnum
+        ac.spring_mode = SpringModeEnum.BASIC
+        ac.telemffb_controls_axes = True
+        ac.cyclic_spring_init = 1
+        ac.hands_on_active = 0
+        ac.hands_on_x_active = 0
+        ac.hands_on_y_active = 0
+        ac.cpO_x = 0
+        ac.cpO_y = 0
+        # stick centered -> hands-off (deviation 0 < deadzone)
+        self.mock_device._input_data.set_axis(x=0.0, y=0.0)
+        return ac
+
+    def _telem(self, **kw):
+        b = (TelemetryDataBuilder()
+             .ffb_type("joystick")
+             .on_ground(False)
+             .with_field("APMaster", 0))
+        for k, v in kw.items():
+            b = b.with_field(k, v)
+        return b.build()
+
+    def test_sema_positive_drives_cpO_x_negative(self):
+        ac = self._inst()
+        # First rolling-average call returns the value itself: sema_x=20
+        # -> afcsx_step_size = 20 * 0.25 = 5 device units.
+        ac.msfs_update_heli_controls(self._telem(hpgSEMAx=20, hpgSEMAy=0))
+        assert ac.afcsx_step_size == pytest.approx(5.0)
+        assert ac.cpO_x == pytest.approx(-5.0)
+        assert ac.cpO_y == 0
+
+    def test_sema_negative_drives_cpO_x_positive(self):
+        ac = self._inst()
+        ac.msfs_update_heli_controls(self._telem(hpgSEMAx=-20, hpgSEMAy=0))
+        assert ac.cpO_x == pytest.approx(5.0)
+
+    def test_sema_y_drives_cpO_y(self):
+        ac = self._inst()
+        ac.msfs_update_heli_controls(self._telem(hpgSEMAx=0, hpgSEMAy=10))
+        assert ac.afcsy_step_size == pytest.approx(2.5)
+        assert ac.cpO_y == pytest.approx(-2.5)
+
+    def test_spring_cpOffset_tracks_cpO_in_device_units(self):
+        # THE invariant guard: the hardware must see the same device-unit
+        # offset before and after the TASK002 normalization.
+        ac = self._inst()
+        ac.msfs_update_heli_controls(self._telem(hpgSEMAx=20, hpgSEMAy=10))
+        assert ac.spring_x.cpOffset == round(ac.cpO_x)
+        assert ac.spring_y.cpOffset == round(ac.cpO_y)
+        assert ac.spring_x.cpOffset == -5
+        assert ac.spring_y.cpOffset == -2
+
+    def test_hands_on_cyclic_stops_sema_follow(self):
+        ac = self._inst()
+        # Stick deflected far from the spring center -> hands on.  The
+        # hands-on state is dispatched at the END of the frame, so it gates
+        # the SEMA follow from the SECOND frame on.
+        self.mock_device._input_data.set_axis(x=0.5, y=0.0)
+        ac.msfs_update_heli_controls(self._telem(hpgSEMAx=20, hpgSEMAy=0))
+        assert ac.hands_on_active == 1, "deflected stick must dispatch hands-on"
+        # Frame 1 already moved the center (hands-on was latched at the END of
+        # that frame); frame 2 must hold it — SEMA follow is gated off.
+        after_first = ac.cpO_x
+        ac.msfs_update_heli_controls(self._telem(hpgSEMAx=20, hpgSEMAy=0))
+        assert ac.cpO_x == after_first, \
+            "SEMA follow must stop once hands-on is latched"
+
+
+@pytest.mark.unit
+@pytest.mark.msfs
+@pytest.mark.helicopter
+class TestHPGFollowupTrim(BaseTelemetryEffectTestCase):
+    """Frame-rate-independent follow-up trim accumulator (hands on)."""
+
+    def _inst(self):
+        ac = self.create_aircraft_instance(
+            HPGHelicopter, name="HPG H145",
+            _test_sim_is_msfs=True, _test_device_type="joystick")
+        from telemffb.SettingsManager import SpringModeEnum
+        ac.spring_mode = SpringModeEnum.BASIC
+        ac.telemffb_controls_axes = True
+        ac.cyclic_spring_init = 1
+        ac.hands_on_active = 1      # latched hands-on (dispatch normally sets this)
+        ac.hands_on_x_active = 0
+        ac.hands_on_y_active = 0
+        ac.cpO_x = 0
+        ac.cpO_y = 0
+        ac.followup_trim_accumulator = 0.0
+        # stick deflected -> hands on + nonzero deviation drives the follow
+        self.mock_device._input_data.set_axis(x=0.5, y=0.0)
+        return ac
+
+    def _telem(self, **kw):
+        b = (TelemetryDataBuilder()
+             .ffb_type("joystick")
+             .on_ground(False)
+             .with_field("APMaster", 0)
+             .with_field("hpgFollowupTrimMode", 0)   # 0 = always active
+             .with_field("IAS", 0.0))
+        for k, v in kw.items():
+            b = b.with_field(k, v)
+        return b.build()
+
+    def test_followup_trim_steps_toward_stick_deflection(self, monkeypatch):
+        # dt = 10 ms at the default rate (100 units/s) -> 1 device unit/frame.
+        monkeypatch.setattr(
+            hpg_module.perftracker, "get_time_delta", lambda name: 0.01)
+        ac = self._inst()
+        ac.msfs_update_heli_controls(self._telem(hpgSEMAx=0, hpgSEMAy=0))
+        assert ac.cpO_x == pytest.approx(1.0)
+        # accumulator keeps the fractional remainder (0.01*100 = 1 exactly)
+        assert ac.followup_trim_accumulator == pytest.approx(0.0, abs=1e-9)
+
+    def test_followup_accumulator_is_frame_rate_independent(self, monkeypatch):
+        # Two frames at dt=5 ms must move the center the same total distance
+        # as one frame at dt=10 ms (100 units/s in both cases).
+        monkeypatch.setattr(
+            hpg_module.perftracker, "get_time_delta", lambda name: 0.005)
+        ac = self._inst()
+        ac.msfs_update_heli_controls(self._telem(hpgSEMAx=0, hpgSEMAy=0))
+        ac.msfs_update_heli_controls(self._telem(hpgSEMAx=0, hpgSEMAy=0))
+        assert ac.cpO_x == pytest.approx(1.0)
+
+    def test_followup_accumulator_carries_fraction(self, monkeypatch):
+        # dt = 15 ms -> 1.5 units: 1 whole unit applied, 0.5 carried.
+        monkeypatch.setattr(
+            hpg_module.perftracker, "get_time_delta", lambda name: 0.015)
+        ac = self._inst()
+        ac.msfs_update_heli_controls(self._telem(hpgSEMAx=0, hpgSEMAy=0))
+        assert ac.cpO_x == pytest.approx(1.0)
+        assert ac.followup_trim_accumulator == pytest.approx(0.5, abs=1e-9)
+        # Next frame adds another 1.5 -> 0.5+1.5 = 2.0 -> 2 units applied.
+        ac.msfs_update_heli_controls(self._telem(hpgSEMAx=0, hpgSEMAy=0))
+        assert ac.cpO_x == pytest.approx(3.0)
+        assert ac.followup_trim_accumulator == pytest.approx(0.0, abs=1e-9)
+
+    def test_followup_trim_disabled_on_ground(self, monkeypatch):
+        monkeypatch.setattr(
+            hpg_module.perftracker, "get_time_delta", lambda name: 0.01)
+        ac = self._inst()
+        ac.msfs_update_heli_controls(
+            self._telem(hpgSEMAx=0, hpgSEMAy=0, SimOnGround=1))
+        assert ac.cpO_x == 0, "follow-up trim must be suppressed on the ground"
+
+    def test_followup_trim_respects_mode_off(self, monkeypatch):
+        monkeypatch.setattr(
+            hpg_module.perftracker, "get_time_delta", lambda name: 0.01)
+        ac = self._inst()
+        ac.msfs_update_heli_controls(
+            self._telem(hpgSEMAx=0, hpgSEMAy=0, hpgFollowupTrimMode=1))
+        assert ac.cpO_x == 0, "hpgFollowupTrimMode=1 (off) must suppress follow-up"
+
+    def test_followup_spring_cpOffset_tracks_cpO(self, monkeypatch):
+        monkeypatch.setattr(
+            hpg_module.perftracker, "get_time_delta", lambda name: 0.05)
+        ac = self._inst()
+        ac.msfs_update_heli_controls(self._telem(hpgSEMAx=0, hpgSEMAy=0))
+        # 0.05 s * 100 units/s = 5 device units
+        assert ac.cpO_x == pytest.approx(5.0)
+        assert ac.spring_x.cpOffset == round(ac.cpO_x)
+        assert ac.spring_x.cpOffset == 5
+
+
+@pytest.mark.unit
+@pytest.mark.msfs
+@pytest.mark.helicopter
+class TestHPGPedalSemaFollow(BaseTelemetryEffectTestCase):
+    """Pedal (yaw SEMA) spring-center follow."""
+
+    def _inst(self):
+        ac = self.create_aircraft_instance(
+            HPGHelicopter, name="HPG H145",
+            _test_sim_is_msfs=True, _test_device_type="pedals")
+        from telemffb.SettingsManager import SpringModeEnum
+        ac.spring_mode = SpringModeEnum.BASIC
+        ac.telemffb_controls_axes = True
+        ac.pedals_init = 1
+        ac.feet_on_active = 0
+        ac.cpO_x = 0
+        self.mock_device._input_data.set_axis(x=0.0, y=0.0)
+        return ac
+
+    def _telem(self, **kw):
+        b = (TelemetryDataBuilder()
+             .ffb_type("pedals")
+             .on_ground(False)
+             .with_field("APMaster", 0))
+        for k, v in kw.items():
+            b = b.with_field(k, v)
+        return b.build()
+
+    def test_yaw_sema_drives_cpO_x(self):
+        ac = self._inst()
+        # sema_yaw=10 -> afcsx_step_size = 10 * 0.5 = 5 device units
+        telem = self._telem(hpgSEMAyaw=10)
+        ac.msfs_update_pedals(telem)
+        assert ac.afcsx_step_size == pytest.approx(5.0)
+        assert ac.cpO_x == pytest.approx(-5.0)
+        # telemetry exposure: _cp0_x mirrors the pedal spring center
+        assert getattr(telem, "_cp0_x") == pytest.approx(ac.cpO_x)
+
+    def test_pedal_spring_offset_uses_set_offset(self):
+        # The pedal path already routes through set_offset(); with device-unit
+        # cpO_x the mock's magnitude heuristic passes it through unchanged.
+        ac = self._inst()
+        ac.msfs_update_pedals(self._telem(hpgSEMAyaw=10))
+        assert ac.spring_x.cpOffset == round(ac.cpO_x)
+        assert ac.spring_x.cpOffset == -5
+
+    def test_feet_on_pedals_freezes_sema_follow(self):
+        ac = self._inst()
+        # feet_on_active is re-derived each frame from deflection detection:
+        # sim reports feet-on AND the pedals are deflected past the threshold.
+        self.mock_device._input_data.set_axis(x=0.3, y=0.0)
+        ac.msfs_update_pedals(self._telem(hpgSEMAyaw=10, hpgFeetOnPedals=1))
+        assert ac.feet_on_active is True
+        assert ac.cpO_x == 0, "SEMA follow must pause while feet are on the pedals"

--- a/tests/test_msfs_xp_flight_controls.py
+++ b/tests/test_msfs_xp_flight_controls.py
@@ -278,6 +278,47 @@ class TestMsfsXpFlightControlsDynamicPressure(BaseTelemetryEffectTestCase):
         # Assert
         assert abs(telem["Vne_kt"] - 150 * 1.94384) < 0.1
 
+    def test_vne_override_non_numeric_falls_back_to_sim_data(self):
+        """A non-numeric vne_override (e.g. the bare unit string "kt" produced
+        by an empty config value + <unit>kt</unit>) must NOT be used as a speed.
+
+        Regression for the per-frame TypeError in _calculate_vne_and_gains
+        (`vne * ms2kt` on a string) that killed all MSFS FFB after the
+        unit-normalization refactor moved the override check to the top of the
+        method and dropped the isinstance guard. A non-numeric override must
+        fall through to the sim-computed Vne (MSFS: DesignSpeed-derived).
+        """
+        # Arrange
+        instance = self.create_test_instance(MsfsXpFlightControlsMixIn)
+        instance._test_sim_is_msfs = True
+        instance.vne_override = "kt"  # unparseable unit string, not a number
+
+        telem = (
+            TelemetryDataBuilder()
+            .set("src", "MSFS")
+            .set("IAS", 50.0)
+            .set("DesignSpeed", (100.0, 50.0, 60.0))  # Vc, Vs0, Vs1
+            .set("DynPressure", 1000.0)
+            .set("AirDensity", 1.225)
+            .set("PropThrust", 0)
+            .set("Incidence", [0, 0, 1.0])
+            .set("AccBody", [0, 1, 0])
+            .set("RudderDefl", 0.0)
+            .ffb_type("joystick")
+            .build()
+        )
+
+        # Act — must not raise TypeError
+        instance.on_telemetry(telem)
+
+        # Assert: sim-computed Vne is numeric and > 0, and the override string
+        # did not leak into the computed fields.
+        assert isinstance(telem["Vne_ms_calc"], (int, float))
+        assert telem["Vne_ms_calc"] > 0
+        assert isinstance(telem["Vne_kt"], (int, float))
+        assert telem["Vne_kt"] > 0
+        assert telem["Qvc_gain"] > 0
+
 
 class TestMsfsXpFlightControlsCoefficients(BaseTelemetryEffectTestCase):
     """Test suite for control coefficient calculations."""

--- a/tests/test_remaining_spring_center_units.py
+++ b/tests/test_remaining_spring_center_units.py
@@ -56,7 +56,7 @@ class TestGForceOffsetCenterUnits(BaseTelemetryEffectTestCase):
 
         result = instance.ac_update_gforce_effect(telem, adv_spr=True)
 
-        assert result == -2048
+        assert result == pytest.approx(-0.5)
         assert "gforce_spr" not in self.mock_effects.dict
 
     def test_standalone_offset_upload_and_negative_sign(self, monkeypatch):
@@ -110,16 +110,16 @@ class TestAdvancedSpringCenterUnits(BaseTelemetryEffectTestCase):
 
         instance.ac_modify_game_spring()
 
-        assert instance.override_spring_cp0_x == 50
-        assert instance.override_spring_cp0_y == -50
-        assert instance.telem_data._ovrd_spr_step == 50
-        assert instance.telem_data._ovrd_spr_trim_pos[:2] == [50, -50]
+        assert instance.override_spring_cp0_x == pytest.approx(50 / 4096)
+        assert instance.override_spring_cp0_y == pytest.approx(-50 / 4096)
+        assert instance.telem_data._ovrd_spr_step == pytest.approx(50 / 4096)
+        assert instance.telem_data._ovrd_spr_trim_pos[:2] == pytest.approx([50 / 4096, -50 / 4096])
         assert self.mock_effects["adv_spr"].get_offsets() == (50, -50)
 
     def test_trim_clamps_and_reset_uploads_zero(self, monkeypatch):
         instance = self._instance()
-        instance.override_spring_cp0_x = 4080
-        instance.override_spring_cp0_y = -4080
+        instance.override_spring_cp0_x = 4080 / 4096
+        instance.override_spring_cp0_y = -4080 / 4096
         instance.override_spring_trim_rate = 200
         instance.override_spring_trim_right = 2
         instance.override_spring_trim_down = 1
@@ -131,7 +131,7 @@ class TestAdvancedSpringCenterUnits(BaseTelemetryEffectTestCase):
             advanced_spring_module.utils, "get_gain_from_speed", lambda *_args: {"x": 0.5, "y": 0.5})
 
         instance.ac_modify_game_spring()
-        assert (instance.override_spring_cp0_x, instance.override_spring_cp0_y) == (4096, -4096)
+        assert (instance.override_spring_cp0_x, instance.override_spring_cp0_y) == (1.0, -1.0)
         assert self.mock_effects["adv_spr"].get_offsets() == (4096, -4096)
 
         self.mock_device.get_input().release_button(1)
@@ -157,7 +157,7 @@ class TestPedalForceTrimCenterUnits(BaseTelemetryEffectTestCase):
         self.mock_device.get_input().press_button(7)
 
         assert instance.ac_update_pedal_force_trim(instance.telem_data)
-        assert instance.cpO_x == 1024
+        assert instance.cpO_x == pytest.approx(0.25)
         assert instance.spring_x.cpOffset == 1024
 
     def test_cockpit_switch_off_uses_same_capture_path(self):
@@ -165,25 +165,25 @@ class TestPedalForceTrimCenterUnits(BaseTelemetryEffectTestCase):
         self.mock_device.get_input().set_axis(x=-0.3)
 
         assert instance.ac_update_pedal_force_trim(instance.telem_data, ft_active=False)
-        assert instance.cpO_x == round(-0.3 * 4096)
+        assert instance.cpO_x == pytest.approx(-0.3)
         assert instance.spring_x.cpOffset == round(-0.3 * 4096)
 
     def test_reset_uploads_each_intermediate_center(self):
         instance = self._instance()
-        instance.cpO_x = 1024
+        instance.cpO_x = 0.25
         instance.pedal_trim_reset_complete = False
         calls = []
 
         def step(key, value, timeframe_ms, destination, **kwargs):
             calls.append((key, value, timeframe_ms, destination, kwargs))
-            return 768
+            return 768 / 4096
 
         instance.step_value_over_time = step
         assert instance.ac_update_pedal_force_trim(instance.telem_data)
-        assert instance.cpO_x == 768
+        assert instance.cpO_x == pytest.approx(768 / 4096)
         assert instance.spring_x.cpOffset == 768
         assert not instance.pedal_trim_reset_complete
-        assert calls == [("center_x", 1024, 1000, 0, {})]
+        assert calls == [("center_x", 0.25, 1000, 0.0, {"floatpoint": True})]
 
 
 class TestCollectiveForceTrimCenterUnits(BaseTelemetryEffectTestCase):
@@ -216,7 +216,7 @@ class TestCollectiveForceTrimCenterUnits(BaseTelemetryEffectTestCase):
 
         instance.ac_collective_force_trim_override(telem, spring)
 
-        assert instance.collective_ft_ovd_cp0_y == 1024
+        assert instance.collective_ft_ovd_cp0_y == pytest.approx(0.25)
         assert instance.spring_y.cpOffset == 1024
         assert spring.get_offsets()[1] == 1024
         assert spring.start_count == 0
@@ -230,7 +230,7 @@ class TestCollectiveForceTrimCenterUnits(BaseTelemetryEffectTestCase):
         instance.ac_collective_force_trim_override(instance.telem_data, spring)
 
         expected = round(-0.3 * 4096)
-        assert instance.collective_ft_ovd_cp0_y == expected
+        assert instance.collective_ft_ovd_cp0_y == pytest.approx(-0.3)
         assert instance.spring_y.cpOffset == expected
         assert spring.get_offsets()[1] == expected
         assert spring.started
@@ -243,17 +243,17 @@ class TestCollectiveForceTrimCenterUnits(BaseTelemetryEffectTestCase):
             helicopter_effects_module.perftracker, "get_time_delta", lambda _key: 0.5)
 
         instance.ac_collective_force_trim_override(instance.telem_data, spring)
-        assert instance.collective_ft_ovd_cp0_y == 4096
+        assert instance.collective_ft_ovd_cp0_y == 1.0
         assert instance.spring_y.cpOffset == 4096
-        assert instance.telem_data._coll_ft_step == 100
-        assert instance.telem_data._coll_ft_trim_pos == 4096
+        assert instance.telem_data._coll_ft_step == pytest.approx(100 / 4096)
+        assert instance.telem_data._coll_ft_trim_pos == 1.0
 
         self.mock_device.get_input().release_button(6)
         self.mock_device.get_input().press_button(8)
         instance.ac_collective_force_trim_override(instance.telem_data, spring)
-        assert instance.collective_ft_ovd_cp0_y == 3996
+        assert instance.collective_ft_ovd_cp0_y == pytest.approx(3996 / 4096)
         assert instance.spring_y.cpOffset == 3996
-        assert instance.telem_data._coll_ft_trim_pos == 3996
+        assert instance.telem_data._coll_ft_trim_pos == pytest.approx(3996 / 4096)
 
 
 class TestDcsSpringCenterUnits(BaseTelemetryEffectTestCase):
@@ -275,13 +275,13 @@ class TestDcsSpringCenterUnits(BaseTelemetryEffectTestCase):
         self.mock_device.get_input().set_axis(y=1.0)
 
         instance.dcs_override_collective_spring(telem)
-        assert instance.cpO_y == 4096
+        assert instance.cpO_y == 1.0
         assert instance.spring_y.cpOffset == 4096
         assert instance.collective_init == 1
 
         self.mock_device.get_input().set_axis(y=0.35)
         instance.dcs_override_collective_spring(telem)
-        assert instance.cpO_y == round(0.35 * 4096)
+        assert instance.cpO_y == pytest.approx(0.35)
         assert instance.spring_y.cpOffset == round(0.35 * 4096)
 
     def test_pedal_trim_converts_only_at_condition_boundary(self, monkeypatch):
@@ -309,7 +309,7 @@ class TestDcsSpringCenterUnits(BaseTelemetryEffectTestCase):
         monkeypatch.setattr(dcs_module.perftracker, "get_time_delta", lambda _key: 0.25)
 
         instance.dcs_override_spring()
-        assert (instance.override_spring_cp0_x, instance.override_spring_cp0_y) == (1024, -2048)
+        assert (instance.override_spring_cp0_x, instance.override_spring_cp0_y) == (0.25, -0.5)
         assert (instance.spring_x.cpOffset, instance.spring_y.cpOffset) == (1024, -2048)
 
         self.mock_device.get_input().release_button(4)
@@ -318,10 +318,12 @@ class TestDcsSpringCenterUnits(BaseTelemetryEffectTestCase):
         self.mock_device.get_input().press_button(5)
         self.mock_device.get_input().press_button(6)
         instance.dcs_override_spring()
-        assert (instance.override_spring_cp0_x, instance.override_spring_cp0_y) == (1074, -2098)
+        assert (instance.override_spring_cp0_x, instance.override_spring_cp0_y) == pytest.approx(
+            (1074 / 4096, -2098 / 4096))
         assert (instance.spring_x.cpOffset, instance.spring_y.cpOffset) == (1074, -2098)
-        assert instance.telem_data._ovrd_spr_step == 50
-        assert instance.telem_data._ovrd_spr_trim_pos == [1074, -2098]
+        assert instance.telem_data._ovrd_spr_step == pytest.approx(50 / 4096)
+        assert instance.telem_data._ovrd_spr_trim_pos == pytest.approx(
+            [1074 / 4096, -2098 / 4096])
 
 
 class TestIl2SpringCenterUnits(BaseTelemetryEffectTestCase):
@@ -335,16 +337,16 @@ class TestIl2SpringCenterUnits(BaseTelemetryEffectTestCase):
         instance.override_spring_trim_rate = 200
         instance.override_spring_trim_right = 5
         instance.override_spring_trim_down = 6
-        instance.override_spring_cp0_x = 4080
-        instance.override_spring_cp0_y = -4080
+        instance.override_spring_cp0_x = 4080 / 4096
+        instance.override_spring_cp0_y = -4080 / 4096
         self.mock_device.get_input().press_button(5)
         self.mock_device.get_input().press_button(6)
         monkeypatch.setattr(il2_module.perftracker, "get_time_delta", lambda _key: 0.25)
 
         instance.il2_override_spring()
 
-        assert (instance.override_spring_cp0_x, instance.override_spring_cp0_y) == (4096, -4096)
+        assert (instance.override_spring_cp0_x, instance.override_spring_cp0_y) == (1.0, -1.0)
         assert (instance.spring_x.cpOffset, instance.spring_y.cpOffset) == (4096, -4096)
-        assert instance.telem_data._ovrd_spr_step == 50
-        assert instance.telem_data._ovrd_spr_trim_pos == [4096, -4096]
+        assert instance.telem_data._ovrd_spr_step == pytest.approx(50 / 4096)
+        assert instance.telem_data._ovrd_spr_trim_pos == [1.0, -1.0]
         assert self.mock_effects["il2_spr_override"].started

--- a/tests/test_remaining_spring_center_units.py
+++ b/tests/test_remaining_spring_center_units.py
@@ -1,0 +1,350 @@
+"""Characterization coverage for TASK003 spring-center normalization.
+
+Hardware-facing ``cpOffset`` assertions stay in Rhino device units across the
+refactor.  Assertions on cached centers and private diagnostic telemetry start
+in the legacy device-unit representation and are updated to normalized values
+when the corresponding production phase lands.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import telemffb.globals as G
+import telemffb.sim.aircrafts_dcs as dcs_module
+import telemffb.sim.aircrafts_il2 as il2_module
+import telemffb.sim.base.AdvancedSpringMixIn as advanced_spring_module
+import telemffb.sim.base.GForceEffectMixIn as gforce_module
+import telemffb.sim.base.HelicopterEffectsMixIn as helicopter_effects_module
+from telemffb.SettingsManager import GEffectModeEnum, SpringModeEnum
+from telemffb.sim.BaseTelemetryData import BaseTelemetryData
+from telemffb.sim.aircrafts_dcs import Aircraft as DcsAircraft
+from telemffb.sim.aircrafts_il2 import Aircraft as Il2Aircraft
+from telemffb.sim.base.AdvancedSpringMixIn import AdvancedSpringMixIn
+from telemffb.sim.base.GForceEffectMixIn import GForceEffectMixIn
+from telemffb.sim.base.HelicopterEffectsMixIn import HelicopterEffectsMixIn
+from telemffb.sim.base.PedalSpringOverrideMixIn import PedalSpringOverrideMixIn
+from tests.framework.base import BaseTelemetryEffectTestCase
+
+
+class TestGForceOffsetCenterUnits(BaseTelemetryEffectTestCase):
+    def _instance(self, gs=3.0):
+        G.device_firmware_version = "v1.0.18"
+        instance = self.create_test_instance(GForceEffectMixIn)
+        instance.gforce_effect_mode = GEffectModeEnum.ADVANCED
+        instance.gforce_effect_adv_curve = {
+            "mode": "offset",
+            "enable_neg": True,
+        }
+        telem = BaseTelemetryData({
+            "src": "MSFS",
+            "FFBType": "joystick",
+            "G": gs,
+            "AccBody": [0.0, 0.0, 0.0],
+            "TAS": 50.0,
+            "WeightOnWheels": [0],
+        })
+        instance._telem_data = telem
+        instance._last_telem_data = telem.copy()
+        return instance, telem
+
+    def test_adv_spring_return_is_exact_device_offset_before_refactor(self, monkeypatch):
+        instance, telem = self._instance(gs=3.0)
+        monkeypatch.setattr(gforce_module.utils, "get_gain_from_gs", lambda *_args: (0.5, 0.25))
+
+        result = instance.ac_update_gforce_effect(telem, adv_spr=True)
+
+        assert result == -2048
+        assert "gforce_spr" not in self.mock_effects.dict
+
+    def test_standalone_offset_upload_and_negative_sign(self, monkeypatch):
+        instance, telem = self._instance(gs=-2.0)
+        monkeypatch.setattr(gforce_module.utils, "get_gain_from_gs", lambda *_args: (0.5, 0.25))
+
+        instance.ac_update_gforce_effect(telem)
+
+        effect = self.mock_effects["gforce_spr"]
+        assert effect.started
+        assert effect.get_offsets() == (0, 1024)
+        assert effect._x_saturation == 4096
+        assert effect._y_saturation == 4096
+
+
+class TestAdvancedSpringCenterUnits(BaseTelemetryEffectTestCase):
+    def _instance(self):
+        G.device_firmware_version = "v1.0.18"
+        instance = self.create_test_instance(AdvancedSpringMixIn)
+        instance.spring_mode = SpringModeEnum.ADVANCED
+        instance.adv_spr_gains = json.dumps({
+            "gain_x": 100,
+            "gain_y": 100,
+            "curve_x": {"points": []},
+            "curve_y": {"points": []},
+            "units": "m/s",
+        })
+        instance.gforce_effect_mode = GEffectModeEnum.DISABLED
+        instance.adv_spr_use_hardware_trim = True
+        instance._telem_data = BaseTelemetryData({
+            "src": "DCS",
+            "FFBType": "joystick",
+            "IAS": 50.0,
+            "TAS": 50.0,
+            "WeightOnWheels": [0],
+            "ACCs": [0.0, 1.0, 0.0],
+        })
+        return instance
+
+    def test_hat_trim_preserves_rate_and_device_output(self, monkeypatch):
+        instance = self._instance()
+        instance.override_spring_trim_rate = 200
+        instance.override_spring_trim_down = 1
+        instance.override_spring_trim_right = 2
+        self.mock_device.get_input().press_button(1)
+        self.mock_device.get_input().press_button(2)
+        monkeypatch.setattr(
+            advanced_spring_module.perftracker, "get_time_delta", lambda _key: 0.25)
+        monkeypatch.setattr(
+            advanced_spring_module.utils, "get_gain_from_speed", lambda *_args: {"x": 0.5, "y": 0.5})
+
+        instance.ac_modify_game_spring()
+
+        assert instance.override_spring_cp0_x == 50
+        assert instance.override_spring_cp0_y == -50
+        assert instance.telem_data._ovrd_spr_step == 50
+        assert instance.telem_data._ovrd_spr_trim_pos[:2] == [50, -50]
+        assert self.mock_effects["adv_spr"].get_offsets() == (50, -50)
+
+    def test_trim_clamps_and_reset_uploads_zero(self, monkeypatch):
+        instance = self._instance()
+        instance.override_spring_cp0_x = 4080
+        instance.override_spring_cp0_y = -4080
+        instance.override_spring_trim_rate = 200
+        instance.override_spring_trim_right = 2
+        instance.override_spring_trim_down = 1
+        self.mock_device.get_input().press_button(1)
+        self.mock_device.get_input().press_button(2)
+        monkeypatch.setattr(
+            advanced_spring_module.perftracker, "get_time_delta", lambda _key: 0.25)
+        monkeypatch.setattr(
+            advanced_spring_module.utils, "get_gain_from_speed", lambda *_args: {"x": 0.5, "y": 0.5})
+
+        instance.ac_modify_game_spring()
+        assert (instance.override_spring_cp0_x, instance.override_spring_cp0_y) == (4096, -4096)
+        assert self.mock_effects["adv_spr"].get_offsets() == (4096, -4096)
+
+        self.mock_device.get_input().release_button(1)
+        self.mock_device.get_input().release_button(2)
+        instance.override_spring_trim_reset = 3
+        self.mock_device.get_input().press_button(3)
+        instance.ac_modify_game_spring()
+        assert (instance.override_spring_cp0_x, instance.override_spring_cp0_y) == (0, 0)
+        assert self.mock_effects["adv_spr"].get_offsets() == (0, 0)
+
+
+class TestPedalForceTrimCenterUnits(BaseTelemetryEffectTestCase):
+    def _instance(self):
+        instance = self.create_test_instance(PedalSpringOverrideMixIn)
+        instance._telem_data = BaseTelemetryData({"src": "DCS", "FFBType": "pedals"})
+        instance.pedal_ft_release_button = 7
+        instance.pedal_ft_reset_button = 8
+        return instance
+
+    def test_release_captures_center_and_device_output(self):
+        instance = self._instance()
+        self.mock_device.get_input().set_axis(x=0.25)
+        self.mock_device.get_input().press_button(7)
+
+        assert instance.ac_update_pedal_force_trim(instance.telem_data)
+        assert instance.cpO_x == 1024
+        assert instance.spring_x.cpOffset == 1024
+
+    def test_cockpit_switch_off_uses_same_capture_path(self):
+        instance = self._instance()
+        self.mock_device.get_input().set_axis(x=-0.3)
+
+        assert instance.ac_update_pedal_force_trim(instance.telem_data, ft_active=False)
+        assert instance.cpO_x == round(-0.3 * 4096)
+        assert instance.spring_x.cpOffset == round(-0.3 * 4096)
+
+    def test_reset_uploads_each_intermediate_center(self):
+        instance = self._instance()
+        instance.cpO_x = 1024
+        instance.pedal_trim_reset_complete = False
+        calls = []
+
+        def step(key, value, timeframe_ms, destination, **kwargs):
+            calls.append((key, value, timeframe_ms, destination, kwargs))
+            return 768
+
+        instance.step_value_over_time = step
+        assert instance.ac_update_pedal_force_trim(instance.telem_data)
+        assert instance.cpO_x == 768
+        assert instance.spring_x.cpOffset == 768
+        assert not instance.pedal_trim_reset_complete
+        assert calls == [("center_x", 1024, 1000, 0, {})]
+
+
+class TestCollectiveForceTrimCenterUnits(BaseTelemetryEffectTestCase):
+    def _instance(self, telem=None):
+        instance = self.create_test_instance(HelicopterEffectsMixIn)
+        instance.spring_mode = SpringModeEnum.FORCETRIM
+        instance.collective_ft_ovd_release = 5
+        instance.collective_ft_ovd_reset = 6
+        instance.collective_ft_ovd_trim_down = 7
+        instance.collective_ft_ovd_trim_up = 8
+        instance.collective_ft_use_master_buttons = False
+        instance._telem_data = telem or BaseTelemetryData({
+            "src": "DCS",
+            "FFBType": "collective",
+            "WeightOnWheels": [0],
+            "ForceTrimSW": True,
+        })
+        return instance
+
+    def test_cockpit_switch_off_tracks_axis_without_starting(self):
+        telem = BaseTelemetryData({
+            "src": "DCS",
+            "FFBType": "collective",
+            "WeightOnWheels": [0],
+            "ForceTrimSW": False,
+        })
+        instance = self._instance(telem)
+        spring = self.mock_effects["collective_ft"].spring()
+        self.mock_device.get_input().set_axis(y=0.25)
+
+        instance.ac_collective_force_trim_override(telem, spring)
+
+        assert instance.collective_ft_ovd_cp0_y == 1024
+        assert instance.spring_y.cpOffset == 1024
+        assert spring.get_offsets()[1] == 1024
+        assert spring.start_count == 0
+
+    def test_release_tracks_axis_and_starts_effect(self):
+        instance = self._instance()
+        spring = self.mock_effects["collective_ft"].spring()
+        self.mock_device.get_input().set_axis(y=-0.3)
+        self.mock_device.get_input().press_button(5)
+
+        instance.ac_collective_force_trim_override(instance.telem_data, spring)
+
+        expected = round(-0.3 * 4096)
+        assert instance.collective_ft_ovd_cp0_y == expected
+        assert instance.spring_y.cpOffset == expected
+        assert spring.get_offsets()[1] == expected
+        assert spring.started
+
+    def test_reset_and_hat_trim_preserve_device_units(self, monkeypatch):
+        instance = self._instance()
+        spring = self.mock_effects["collective_ft"].spring()
+        self.mock_device.get_input().press_button(6)
+        monkeypatch.setattr(
+            helicopter_effects_module.perftracker, "get_time_delta", lambda _key: 0.5)
+
+        instance.ac_collective_force_trim_override(instance.telem_data, spring)
+        assert instance.collective_ft_ovd_cp0_y == 4096
+        assert instance.spring_y.cpOffset == 4096
+        assert instance.telem_data._coll_ft_step == 100
+        assert instance.telem_data._coll_ft_trim_pos == 4096
+
+        self.mock_device.get_input().release_button(6)
+        self.mock_device.get_input().press_button(8)
+        instance.ac_collective_force_trim_override(instance.telem_data, spring)
+        assert instance.collective_ft_ovd_cp0_y == 3996
+        assert instance.spring_y.cpOffset == 3996
+        assert instance.telem_data._coll_ft_trim_pos == 3996
+
+
+class TestDcsSpringCenterUnits(BaseTelemetryEffectTestCase):
+    def _instance(self, ffb_type="joystick"):
+        instance = self.create_aircraft_instance(DcsAircraft, name="DCS Test")
+        telem = BaseTelemetryData({
+            "src": "DCS",
+            "FFBType": ffb_type,
+            "WeightOnWheels": [0],
+            "ForceTrimSW": True,
+        })
+        self.set_telemetry(instance, telem)
+        return instance, telem
+
+    def test_collective_ground_init_and_follow_output(self):
+        instance, telem = self._instance("collective")
+        telem.WeightOnWheels = [1]
+        self.set_telemetry(instance, telem)
+        self.mock_device.get_input().set_axis(y=1.0)
+
+        instance.dcs_override_collective_spring(telem)
+        assert instance.cpO_y == 4096
+        assert instance.spring_y.cpOffset == 4096
+        assert instance.collective_init == 1
+
+        self.mock_device.get_input().set_axis(y=0.35)
+        instance.dcs_override_collective_spring(telem)
+        assert instance.cpO_y == round(0.35 * 4096)
+        assert instance.spring_y.cpOffset == round(0.35 * 4096)
+
+    def test_pedal_trim_converts_only_at_condition_boundary(self, monkeypatch):
+        instance, telem = self._instance("pedals")
+        telem.controlsurfaces_rudder_right = -0.4
+        self.mock_device.get_input().set_axis(x=0.1)
+        instance.dcs_send_commands = MagicMock()
+
+        lpf = SimpleNamespace(value=0.0, update=lambda value: value)
+        monkeypatch.setattr(dcs_module, "LPFs", SimpleNamespace(get=lambda *_args: lpf))
+        instance.dcs_update_pedal_trim(telem)
+
+        assert instance.spring_x.cpOffset == round(0.3 * 4096)
+        expected_offset = 0.4 - 0.1
+        instance.dcs_send_commands.assert_called_once_with([
+            f"LoSetCommand(2003, {0.1 - expected_offset})"])
+
+    def test_custom_spring_release_and_hat_trim(self, monkeypatch):
+        instance, _telem = self._instance("joystick")
+        instance.spring_mode = SpringModeEnum.CUSTOM
+        instance.override_spring_ft_enabled = True
+        instance.override_spring_trim_release = 4
+        self.mock_device.get_input().set_axis(x=0.25, y=-0.5)
+        self.mock_device.get_input().press_button(4)
+        monkeypatch.setattr(dcs_module.perftracker, "get_time_delta", lambda _key: 0.25)
+
+        instance.dcs_override_spring()
+        assert (instance.override_spring_cp0_x, instance.override_spring_cp0_y) == (1024, -2048)
+        assert (instance.spring_x.cpOffset, instance.spring_y.cpOffset) == (1024, -2048)
+
+        self.mock_device.get_input().release_button(4)
+        instance.override_spring_trim_right = 5
+        instance.override_spring_trim_down = 6
+        self.mock_device.get_input().press_button(5)
+        self.mock_device.get_input().press_button(6)
+        instance.dcs_override_spring()
+        assert (instance.override_spring_cp0_x, instance.override_spring_cp0_y) == (1074, -2098)
+        assert (instance.spring_x.cpOffset, instance.spring_y.cpOffset) == (1074, -2098)
+        assert instance.telem_data._ovrd_spr_step == 50
+        assert instance.telem_data._ovrd_spr_trim_pos == [1074, -2098]
+
+
+class TestIl2SpringCenterUnits(BaseTelemetryEffectTestCase):
+    def test_custom_spring_hat_trim_and_clamp(self, monkeypatch):
+        instance = self.create_aircraft_instance(Il2Aircraft, name="IL-2 Test")
+        telem = BaseTelemetryData({"src": "IL2", "FFBType": "joystick"})
+        self.set_telemetry(instance, telem)
+        instance.spring_mode = SpringModeEnum.CUSTOM
+        instance.override_spring_ft_enabled = True
+        instance.override_spring_gain = 0.5
+        instance.override_spring_trim_rate = 200
+        instance.override_spring_trim_right = 5
+        instance.override_spring_trim_down = 6
+        instance.override_spring_cp0_x = 4080
+        instance.override_spring_cp0_y = -4080
+        self.mock_device.get_input().press_button(5)
+        self.mock_device.get_input().press_button(6)
+        monkeypatch.setattr(il2_module.perftracker, "get_time_delta", lambda _key: 0.25)
+
+        instance.il2_override_spring()
+
+        assert (instance.override_spring_cp0_x, instance.override_spring_cp0_y) == (4096, -4096)
+        assert (instance.spring_x.cpOffset, instance.spring_y.cpOffset) == (4096, -4096)
+        assert instance.telem_data._ovrd_spr_step == 50
+        assert instance.telem_data._ovrd_spr_trim_pos == [4096, -4096]
+        assert self.mock_effects["il2_spr_override"].started

--- a/tests/test_sas_helicopter.py
+++ b/tests/test_sas_helicopter.py
@@ -1,0 +1,109 @@
+"""Characterization tests for SASHelicopter cyclic SEMA follow.
+
+These tests pin the observable behavior of the SAS cyclic path BEFORE the
+cpO_* unit normalization (TASK002): the spring center (cpO_x/cpO_y) is
+expressed in DEVICE units (0..4096) and written raw to spring.cpOffset.
+
+The device-unit ``spring_x/y.cpOffset`` assertions are the invariant
+regression guard: after TASK002 normalizes cpO_* to -1..1, the hardware must
+still receive the same device-unit offsets (via the type-sniffing
+``set_offset()``), so these assertions must keep passing unchanged. Only the
+internal ``cpO_*`` assertions are expected to be rewritten in normalized
+units.
+"""
+import pytest
+
+import telemffb.globals as G
+from tests.framework.base import BaseTelemetryEffectTestCase
+from tests.framework.utils import TelemetryDataBuilder
+from telemffb.sim.msfs_xp.SASHelicopter import SASHelicopter
+
+
+@pytest.fixture(autouse=True)
+def _firmware_version():
+    G.device_firmware_version = "1.0.18"
+    yield
+    G.device_firmware_version = None
+
+
+@pytest.mark.unit
+@pytest.mark.msfs
+@pytest.mark.helicopter
+class TestSASCyclicSemaFollow(BaseTelemetryEffectTestCase):
+    """SEMA-driven spring-center follow (hands off the cyclic)."""
+
+    def _inst(self):
+        ac = self.create_aircraft_instance(
+            SASHelicopter, name="SAS H160",
+            _test_sim_is_msfs=True, _test_device_type="joystick")
+        from telemffb.SettingsManager import SpringModeEnum
+        ac.spring_mode = SpringModeEnum.BASIC
+        ac.telemffb_controls_axes = True
+        ac.cyclic_spring_init = 1
+        ac.hands_on_active = 0
+        ac.hands_on_x_active = 0
+        ac.hands_on_y_active = 0
+        ac.cpO_x = 0
+        ac.cpO_y = 0
+        # stick centered -> hands-off (deviation 0 < deadzone)
+        self.mock_device._input_data.set_axis(x=0.0, y=0.0)
+        return ac
+
+    def _telem(self, **kw):
+        b = (TelemetryDataBuilder()
+             .ffb_type("joystick")
+             .on_ground(False)
+             .with_field("APMaster", 0))
+        for k, v in kw.items():
+            b = b.with_field(k, v)
+        return b.build()
+
+    def test_sema_x_step_size_is_0_1x(self):
+        ac = self._inst()
+        # First rolling-average call returns the value itself: sema_x=20
+        # -> afcsx_step_size = 20 * 0.1 = 2 device units.
+        ac.msfs_update_heli_controls(self._telem(SEMAx=20, SEMAy=0))
+        assert ac.afcsx_step_size == pytest.approx(2.0)
+        assert ac.cpO_x == pytest.approx(-2.0)
+
+    def test_sema_y_step_size_is_0_3x(self):
+        ac = self._inst()
+        # sema_y=10 -> afcsy_step_size = 10 * 0.3 = 3 device units
+        ac.msfs_update_heli_controls(self._telem(SEMAx=0, SEMAy=10))
+        assert ac.afcsy_step_size == pytest.approx(3.0)
+        assert ac.cpO_y == pytest.approx(-3.0)
+
+    def test_sema_sign_direction(self):
+        ac = self._inst()
+        ac.msfs_update_heli_controls(self._telem(SEMAx=-20, SEMAy=-10))
+        assert ac.cpO_x == pytest.approx(2.0)
+        assert ac.cpO_y == pytest.approx(3.0)
+
+    def test_spring_cpOffset_tracks_cpO_in_device_units(self):
+        # THE invariant guard: the hardware must see the same device-unit
+        # offset before and after the TASK002 normalization.
+        ac = self._inst()
+        ac.msfs_update_heli_controls(self._telem(SEMAx=20, SEMAy=10))
+        assert ac.spring_x.cpOffset == round(ac.cpO_x)
+        assert ac.spring_y.cpOffset == round(ac.cpO_y)
+        assert ac.spring_x.cpOffset == -2
+        assert ac.spring_y.cpOffset == -3
+
+    def test_hands_on_stops_sema_follow(self):
+        ac = self._inst()
+        # Hands-on state is dispatched at the END of the frame; frame 1 moves
+        # the center, frame 2 must hold it.
+        self.mock_device._input_data.set_axis(x=0.5, y=0.0)
+        ac.msfs_update_heli_controls(self._telem(SEMAx=20, SEMAy=0))
+        assert ac.hands_on_active == 1
+        after_first = ac.cpO_x
+        ac.msfs_update_heli_controls(self._telem(SEMAx=20, SEMAy=0))
+        assert ac.cpO_x == after_first, \
+            "SEMA follow must stop once hands-on is latched"
+
+    def test_trim_release_freezes_follow(self):
+        ac = self._inst()
+        ac.msfs_update_heli_controls(
+            self._telem(SEMAx=20, SEMAy=0, hpgTrimRelease=1))
+        assert ac.cpO_x == 0 and ac.cpO_y == 0, \
+            "trim release must freeze the SEMA follow"

--- a/tests/test_sas_helicopter.py
+++ b/tests/test_sas_helicopter.py
@@ -1,15 +1,11 @@
 """Characterization tests for SASHelicopter cyclic SEMA follow.
 
-These tests pin the observable behavior of the SAS cyclic path BEFORE the
-cpO_* unit normalization (TASK002): the spring center (cpO_x/cpO_y) is
-expressed in DEVICE units (0..4096) and written raw to spring.cpOffset.
+These tests pin the observable behavior of the SAS cyclic path after the
+TASK002 unit normalization: the spring center (cpO_x/cpO_y) is expressed as
+a normalized float while ``set_offset()`` performs the device-unit conversion.
 
 The device-unit ``spring_x/y.cpOffset`` assertions are the invariant
-regression guard: after TASK002 normalizes cpO_* to -1..1, the hardware must
-still receive the same device-unit offsets (via the type-sniffing
-``set_offset()``), so these assertions must keep passing unchanged. Only the
-internal ``cpO_*`` assertions are expected to be rewritten in normalized
-units.
+regression guard: the hardware must still receive the same device-unit offsets.
 """
 import pytest
 
@@ -61,31 +57,31 @@ class TestSASCyclicSemaFollow(BaseTelemetryEffectTestCase):
     def test_sema_x_step_size_is_0_1x(self):
         ac = self._inst()
         # First rolling-average call returns the value itself: sema_x=20
-        # -> afcsx_step_size = 20 * 0.1 = 2 device units.
+        # -> historical 2-device-unit step = 2/4096 normalized.
         ac.msfs_update_heli_controls(self._telem(SEMAx=20, SEMAy=0))
-        assert ac.afcsx_step_size == pytest.approx(2.0)
-        assert ac.cpO_x == pytest.approx(-2.0)
+        assert ac.afcsx_step_size == pytest.approx(2 / 4096)
+        assert ac.cpO_x == pytest.approx(-2 / 4096)
 
     def test_sema_y_step_size_is_0_3x(self):
         ac = self._inst()
-        # sema_y=10 -> afcsy_step_size = 10 * 0.3 = 3 device units
+        # sema_y=10 -> historical 3-device-unit step = 3/4096 normalized
         ac.msfs_update_heli_controls(self._telem(SEMAx=0, SEMAy=10))
-        assert ac.afcsy_step_size == pytest.approx(3.0)
-        assert ac.cpO_y == pytest.approx(-3.0)
+        assert ac.afcsy_step_size == pytest.approx(3 / 4096)
+        assert ac.cpO_y == pytest.approx(-3 / 4096)
 
     def test_sema_sign_direction(self):
         ac = self._inst()
         ac.msfs_update_heli_controls(self._telem(SEMAx=-20, SEMAy=-10))
-        assert ac.cpO_x == pytest.approx(2.0)
-        assert ac.cpO_y == pytest.approx(3.0)
+        assert ac.cpO_x == pytest.approx(2 / 4096)
+        assert ac.cpO_y == pytest.approx(3 / 4096)
 
     def test_spring_cpOffset_tracks_cpO_in_device_units(self):
         # THE invariant guard: the hardware must see the same device-unit
         # offset before and after the TASK002 normalization.
         ac = self._inst()
         ac.msfs_update_heli_controls(self._telem(SEMAx=20, SEMAy=10))
-        assert ac.spring_x.cpOffset == round(ac.cpO_x)
-        assert ac.spring_y.cpOffset == round(ac.cpO_y)
+        assert ac.spring_x.cpOffset == round(ac.cpO_x * 4096)
+        assert ac.spring_y.cpOffset == round(ac.cpO_y * 4096)
         assert ac.spring_x.cpOffset == -2
         assert ac.spring_y.cpOffset == -3
 

--- a/tests/test_trim_calibrator.py
+++ b/tests/test_trim_calibrator.py
@@ -9,6 +9,7 @@ import math
 import time
 
 import pytest
+from unittest.mock import Mock
 
 import telemffb.globals as G
 from telemffb.sim.BaseTelemetryData import BaseTelemetryData
@@ -37,6 +38,12 @@ class FakeSpring:
 
     def set_coefficient(self, c):
         self.coeff = c
+
+    def set_offset(self, offset):
+        """Mirror the production FFBReport_SetCondition.set_offset type-sniff:
+        a normalized float (|v| <= 1) is scaled by 4096 and rounded; a
+        device-unit int/float (|v| > 1) passes through as an int."""
+        self.cpOffset = round(offset * 4096) if abs(offset) <= 1 else int(offset)
 
 
 class FakeSpringHandle:
@@ -1256,7 +1263,7 @@ class TestTrimCurve:
         assert piecewise_linear(xs, ys, -0.1) == pytest.approx(0.1)
         assert piecewise_linear(xs, ys, 0.1) == pytest.approx(-0.2)
         assert piecewise_linear(xs, ys, 0.2) == pytest.approx(-0.4)
-        # beyond the band the edge segment's slope continues
+       
         assert piecewise_linear(xs, ys, -0.3) == pytest.approx(0.3)
         assert piecewise_linear(xs, ys, 0.3) == pytest.approx(-0.6)
 
@@ -3043,3 +3050,91 @@ class TestInertTrimDetection:
         cal.start()
         state = run_to_completion(cal, ac, clock)
         assert state == CalState.DONE, f"ended in {state} ({cal.abort_reason})"
+
+
+# --------------------------------------------------------------------------- #
+#  Hold-spring unit plumbing (TASK002 pre-refactor characterization)
+# --------------------------------------------------------------------------- #
+
+class TestHoldSpringUnits:
+    """Pins the hold-spring unit conventions BEFORE the TASK002 normalization.
+
+    Today the hold center (_hold_offs) is stored in DEVICE units (0..4096),
+    read from the raw axes (x CPOFFSET_RANGE) or from spring.cpOffset, and
+    written back raw. After TASK002 normalizes it to -1..1, the hardware must
+    still receive the same device-unit offsets (via the type-sniffing
+    set_offset), so the device-unit spring.cpOffset assertions here are the
+    invariant regression guard.
+    """
+
+    def test_hold_offs_seeded_from_raw_axes_in_device_units(self, clock):
+        # Primary path: _hold_offs = raw axes x CPOFFSET_RANGE.
+        ac = FakePlantAircraft()
+        ac.phys_stick = (0.10, -0.30)
+        cal = TrimCalibrator(ac)
+        cal.start()
+        clock.advance(1 / 30.0)
+        cal.update(ac.telem())
+        assert cal._hold_offs == (int(0.10 * 4096), int(-0.30 * 4096))  # int() truncation is the CURRENT convention
+
+    def test_hold_offs_fallback_reads_spring_cpOffset(self, clock):
+        # Fallback path (raw-axis read fails): _hold_offs comes from the
+        # current spring.cpOffset values. NEVER exercised before TASK002.
+        ac = FakePlantAircraft()
+        ac.spring_x.cpOffset = 800
+        ac.spring_y.cpOffset = -1500
+        # break the raw-axis read to force the fallback
+        ac._get_device_raw_axes = Mock(side_effect=RuntimeError("no axes"))
+        cal = TrimCalibrator(ac)
+        cal.start()
+        clock.advance(1 / 30.0)
+        cal.update(ac.telem())
+        assert cal._hold_offs == (800, -1500)
+
+    def test_hold_write_back_uses_device_units(self, clock):
+        # The write-back must deliver the same device-unit offsets to the
+        # hardware before AND after the TASK002 normalization.
+        ac = FakePlantAircraft()
+        ac.phys_stick = (0.10, -0.30)
+        cal = TrimCalibrator(ac)
+        cal.start()
+        clock.advance(1 / 30.0)
+        cal.update(ac.telem())
+        assert ac.spring_x.cpOffset == pytest.approx(0.10 * 4096, abs=2)
+        assert ac.spring_y.cpOffset == pytest.approx(-0.30 * 4096, abs=2)
+
+    def test_release_hold_targets_are_device_units(self, clock):
+        # _release_hold_targets converts the normalized stick command
+        # (u_ail/u_elev) into device units via CPOFFSET_RANGE.
+        ac = FakePlantAircraft()
+        cal = TrimCalibrator(ac)
+        cal._u_ail = 0.25
+        cal._u_elev = -0.5
+        targets = cal._release_hold_targets(ac.telem())
+        assert targets == (int(0.25 * 4096), int(-0.5 * 4096))
+
+    def test_walk_hold_toward_slews_at_hold_walk_rate(self, clock):
+        # _walk_hold_toward moves _hold_offs at HOLD_WALK_RATE device units/s.
+        ac = FakePlantAircraft()
+        cal = TrimCalibrator(ac)
+        cal._hold_offs = (0, 0)
+        dt = 1 / 30.0
+        arrived = cal._walk_hold_toward((1000, -2000), dt)
+        assert not arrived, "one frame cannot cover 1000 units at 3000/s"
+        step = cal.HOLD_WALK_RATE * dt   # 100 device units
+        assert cal._hold_offs == (step, -step)
+
+    def test_walk_hold_toward_arrives_and_snaps(self, clock):
+        ac = FakePlantAircraft()
+        cal = TrimCalibrator(ac)
+        cal._hold_offs = (0, 0)
+        dt = 1 / 30.0
+        # target within one step -> arrives immediately
+        assert cal._walk_hold_toward((50, -50), dt) is True
+        assert cal._hold_offs == (50, -50)
+
+    def test_walk_hold_toward_none_seeds_targets(self, clock):
+        ac = FakePlantAircraft()
+        cal = TrimCalibrator(ac)
+        assert cal._walk_hold_toward((123, -456), 1 / 30.0) is True
+        assert cal._hold_offs == (123, -456)

--- a/tests/test_trim_calibrator.py
+++ b/tests/test_trim_calibrator.py
@@ -2628,7 +2628,7 @@ class TestThrottleTracking:
             if cal.state in (CalState.DONE, CalState.ABORT):
                 break
         assert cal.state == CalState.DONE, f"ended {cal.state} ({cal.abort_reason})"
-        limit = cal.HOLD_WALK_RATE * dt * 1.5   # rate + rounding slack
+        limit = cal.HOLD_WALK_RATE * dt * 4096 * 1.5   # device units + rounding slack
         assert max_jump <= limit, \
             f"spring center jumped {max_jump:.0f} units in one frame (limit {limit:.0f})"
 
@@ -3053,33 +3053,24 @@ class TestInertTrimDetection:
 
 
 # --------------------------------------------------------------------------- #
-#  Hold-spring unit plumbing (TASK002 pre-refactor characterization)
+#  Hold-spring unit plumbing (TASK002 normalized implementation)
 # --------------------------------------------------------------------------- #
 
 class TestHoldSpringUnits:
-    """Pins the hold-spring unit conventions BEFORE the TASK002 normalization.
+    """Pins normalized hold centers and device-unit spring output."""
 
-    Today the hold center (_hold_offs) is stored in DEVICE units (0..4096),
-    read from the raw axes (x CPOFFSET_RANGE) or from spring.cpOffset, and
-    written back raw. After TASK002 normalizes it to -1..1, the hardware must
-    still receive the same device-unit offsets (via the type-sniffing
-    set_offset), so the device-unit spring.cpOffset assertions here are the
-    invariant regression guard.
-    """
-
-    def test_hold_offs_seeded_from_raw_axes_in_device_units(self, clock):
-        # Primary path: _hold_offs = raw axes x CPOFFSET_RANGE.
+    def test_hold_offs_seeded_from_raw_axes_in_normalized_units(self, clock):
+        # Primary path: _hold_offs directly retains normalized raw axes.
         ac = FakePlantAircraft()
         ac.phys_stick = (0.10, -0.30)
         cal = TrimCalibrator(ac)
         cal.start()
         clock.advance(1 / 30.0)
         cal.update(ac.telem())
-        assert cal._hold_offs == (int(0.10 * 4096), int(-0.30 * 4096))  # int() truncation is the CURRENT convention
+        assert cal._hold_offs == pytest.approx((0.10, -0.30))
 
     def test_hold_offs_fallback_reads_spring_cpOffset(self, clock):
-        # Fallback path (raw-axis read fails): _hold_offs comes from the
-        # current spring.cpOffset values. NEVER exercised before TASK002.
+        # Fallback path converts the device-unit cpOffset fields to normalized.
         ac = FakePlantAircraft()
         ac.spring_x.cpOffset = 800
         ac.spring_y.cpOffset = -1500
@@ -3089,7 +3080,7 @@ class TestHoldSpringUnits:
         cal.start()
         clock.advance(1 / 30.0)
         cal.update(ac.telem())
-        assert cal._hold_offs == (800, -1500)
+        assert cal._hold_offs == pytest.approx((800 / 4096, -1500 / 4096))
 
     def test_hold_write_back_uses_device_units(self, clock):
         # The write-back must deliver the same device-unit offsets to the
@@ -3103,26 +3094,25 @@ class TestHoldSpringUnits:
         assert ac.spring_x.cpOffset == pytest.approx(0.10 * 4096, abs=2)
         assert ac.spring_y.cpOffset == pytest.approx(-0.30 * 4096, abs=2)
 
-    def test_release_hold_targets_are_device_units(self, clock):
-        # _release_hold_targets converts the normalized stick command
-        # (u_ail/u_elev) into device units via CPOFFSET_RANGE.
+    def test_release_hold_targets_are_normalized(self, clock):
+        # Release-continuity targets remain in normalized stick space.
         ac = FakePlantAircraft()
         cal = TrimCalibrator(ac)
         cal._u_ail = 0.25
         cal._u_elev = -0.5
         targets = cal._release_hold_targets(ac.telem())
-        assert targets == (int(0.25 * 4096), int(-0.5 * 4096))
+        assert targets == pytest.approx((0.25, -0.5))
 
     def test_walk_hold_toward_slews_at_hold_walk_rate(self, clock):
-        # _walk_hold_toward moves _hold_offs at HOLD_WALK_RATE device units/s.
+        # _walk_hold_toward moves _hold_offs at the equivalent normalized rate.
         ac = FakePlantAircraft()
         cal = TrimCalibrator(ac)
         cal._hold_offs = (0, 0)
         dt = 1 / 30.0
-        arrived = cal._walk_hold_toward((1000, -2000), dt)
+        arrived = cal._walk_hold_toward((1000 / 4096, -2000 / 4096), dt)
         assert not arrived, "one frame cannot cover 1000 units at 3000/s"
-        step = cal.HOLD_WALK_RATE * dt   # 100 device units
-        assert cal._hold_offs == (step, -step)
+        step = cal.HOLD_WALK_RATE * dt   # 100/4096 normalized units
+        assert cal._hold_offs == pytest.approx((step, -step))
 
     def test_walk_hold_toward_arrives_and_snaps(self, clock):
         ac = FakePlantAircraft()
@@ -3130,11 +3120,13 @@ class TestHoldSpringUnits:
         cal._hold_offs = (0, 0)
         dt = 1 / 30.0
         # target within one step -> arrives immediately
-        assert cal._walk_hold_toward((50, -50), dt) is True
-        assert cal._hold_offs == (50, -50)
+        targets = (50 / 4096, -50 / 4096)
+        assert cal._walk_hold_toward(targets, dt) is True
+        assert cal._hold_offs == pytest.approx(targets)
 
     def test_walk_hold_toward_none_seeds_targets(self, clock):
         ac = FakePlantAircraft()
         cal = TrimCalibrator(ac)
-        assert cal._walk_hold_toward((123, -456), 1 / 30.0) is True
-        assert cal._hold_offs == (123, -456)
+        targets = (123 / 4096, -456 / 4096)
+        assert cal._walk_hold_toward(targets, 1 / 30.0) is True
+        assert cal._hold_offs == pytest.approx(targets)

--- a/tests/test_trimwheel_mixin.py
+++ b/tests/test_trimwheel_mixin.py
@@ -251,15 +251,14 @@ class TestTrimwheelCalibrationHold(BaseTelemetryEffectTestCase):
             "tolerance must return to the button-trim default after release"
 
     def test_expired_hold_does_not_suppress(self):
-        instance = self._trimwheel()
+        instance = self._trimwheel(phys_y=0.05)
+        G.trimcal_hold_until = time.perf_counter() - 1.0   # already expired
         telem = self._telem()
         instance._telem_data = telem
-        # a crashed master left a stale hold behind: TTL already passed
-        G.trimcal_hold_until = time.perf_counter() - 0.1
 
         instance.msfs_update_trimwheel(telem)
 
-        assert len(self._writes(instance)) == 1, "expired hold must not mute the wheel"
+        assert len(self._writes(instance)) == 1
 
 
 class TestTrimwheelLimitFallbacks(BaseTelemetryEffectTestCase):
@@ -300,3 +299,93 @@ class TestTrimwheelLimitFallbacks(BaseTelemetryEffectTestCase):
         assert instance._trimwheel_sim_pos(telem, None) == pytest.approx(0.9)
         no_trim = TelemetryDataBuilder().set("ElevTrimPct", 0.9).build()
         assert instance._trimwheel_sim_pos(no_trim, (-10.0, 10.0)) == pytest.approx(0.9)
+
+
+class TestTrimwheelSpringInit(BaseTelemetryEffectTestCase):
+    """Init-path spring center: untested before TASK002.
+
+    Pins the device-unit spring offset the hardware receives during the
+    init handshake (the invariant hardware contract) and the normalized
+    telemetry exposure.
+    """
+
+    def _trimwheel(self, phys_y=0.0):
+        instance = self.create_test_instance(
+            MsfsXpTrimwheelMixIn,
+            telemffb_controls_axes=True,
+            trimwheel_use_axis=False,
+        )
+        instance._test_sim_is_msfs = True
+        self.mock_device.get_input().set_axis(x=0.0, y=phys_y)
+        return instance
+
+    def _telem(self, **extra):
+        builder = (
+            TelemetryDataBuilder()
+            .ffb_type("trimwheel")
+            .set("APMaster", 0)
+            .set("ElevTrimPct", 0.0)
+        )
+        for key, value in extra.items():
+            builder.set(key, value)
+        return builder.build()
+
+    def test_air_start_seeds_center_from_sim_trim(self):
+        instance = self._trimwheel(phys_y=0.2)
+        telem = self._telem(ElevTrimPct=0.2)
+        instance._telem_data = telem
+
+        instance.msfs_update_trimwheel(telem)
+
+        assert instance.trimwheel_init == 1
+        # init point = sim trim (ElevTrimPct 0.2) in device units
+        assert instance.cpO_y == round(0.2 * 4096)
+        # THE invariant guard: hardware sees the same device-unit offset
+        assert instance.spring_y.cpOffset == round(0.2 * 4096)
+
+    def test_resume_seeds_center_from_last_position(self):
+        instance = self._trimwheel(phys_y=-0.1)
+        instance.last_trimwheel_y = -0.1
+        telem = self._telem(ElevTrimPct=0.0)
+        instance._telem_data = telem
+
+        instance.msfs_update_trimwheel(telem)
+
+        assert instance.trimwheel_init == 1
+        # The init frame seeds cpO_y from last_trimwheel_y, but the follow
+        # path in the SAME frame immediately re-centers to the sim trim
+        # (ElevTrimPct 0.0) — the hardware sees the follow value.
+        assert instance.spring_y.cpOffset == pytest.approx(0.0, abs=2)
+
+    def test_init_gate_blocks_until_wheel_centered(self):
+        instance = self._trimwheel(phys_y=0.5)   # wheel far from trim 0.0
+        telem = self._telem(ElevTrimPct=0.0)
+        instance._telem_data = telem
+
+        instance.msfs_update_trimwheel(telem)
+
+        assert instance.trimwheel_init == 0
+
+    def test_follow_publishes_normalized_center_to_telemetry(self):
+        instance = self._trimwheel(phys_y=0.3)   # wheel at the sim trim
+        telem = self._telem(ElevTrimPct=0.3, ElevTrim=3.0,
+                            ElevTrimMax=10.0, ElevTrimMin=-10.0)
+        instance._telem_data = telem
+
+        instance.msfs_update_trimwheel(telem)   # init frame
+        instance.msfs_update_trimwheel(telem)   # follow frame
+
+        # _tw_cpO_y is the NORMALIZED spring center (invariant meaning)
+        assert telem.get("_tw_cpO_y") == pytest.approx(0.3, abs=0.01)
+        # hardware still receives device units via the type-sniffing setter
+        assert instance.spring_y.cpOffset == pytest.approx(0.3 * 4096, abs=2)
+
+    def test_ap_active_branch_follows_sim_trim(self):
+        instance = self._trimwheel(phys_y=0.4)   # wheel at the sim trim
+        telem = self._telem(ElevTrimPct=0.4, APMaster=1)
+        instance._telem_data = telem
+
+        instance.msfs_update_trimwheel(telem)   # init frame
+        instance.msfs_update_trimwheel(telem)   # AP-active frame
+
+        assert instance.spring_y.cpOffset == pytest.approx(0.4 * 4096, abs=2)

--- a/tests/test_trimwheel_mixin.py
+++ b/tests/test_trimwheel_mixin.py
@@ -338,8 +338,8 @@ class TestTrimwheelSpringInit(BaseTelemetryEffectTestCase):
         instance.msfs_update_trimwheel(telem)
 
         assert instance.trimwheel_init == 1
-        # init point = sim trim (ElevTrimPct 0.2) in device units
-        assert instance.cpO_y == round(0.2 * 4096)
+        # Init point is retained internally in normalized units.
+        assert instance.cpO_y == pytest.approx(0.2)
         # THE invariant guard: hardware sees the same device-unit offset
         assert instance.spring_y.cpOffset == round(0.2 * 4096)
 

--- a/tests/test_xaw109_pedals.py
+++ b/tests/test_xaw109_pedals.py
@@ -9,9 +9,18 @@ rudder_trim_rate whenever it speaks.
 """
 import pytest
 
+import telemffb.globals as G
 from tests.framework.base import BaseTelemetryEffectTestCase
 from tests.framework.utils import TelemetryDataBuilder
 from telemffb.sim.msfs_xp.XAW109Helicopter import XAW109Helicopter
+
+
+@pytest.fixture(autouse=True)
+def _firmware_version():
+    # _get_device_raw_axes() consults the firmware version via the mock device
+    G.device_firmware_version = "1.0.18"
+    yield
+    G.device_firmware_version = None
 
 
 class TestXAW109PedalAfcs(BaseTelemetryEffectTestCase):
@@ -103,3 +112,139 @@ class TestXAW109PedalAfcs(BaseTelemetryEffectTestCase):
                         AW109_ped_force_trim_release_pressed=1)
         ac.msfs_update_pedals(t)
         assert ac.cpO_x == round(0.4 * 4096)
+
+
+@pytest.mark.unit
+@pytest.mark.xplane
+@pytest.mark.helicopter
+class TestXAW109CyclicAfcs(BaseTelemetryEffectTestCase):
+    """Cyclic AFCS follow: trim-rate telemetry drives the spring center.
+
+    Untested before TASK002 — pins the device-unit spring offsets (the
+    invariant hardware contract) and the per-frame step math.
+    """
+
+    def _inst(self):
+        ac = self.create_aircraft_instance(
+            XAW109Helicopter, name="AW109",
+            _test_sim_is_xplane=True, _test_device_type="joystick")
+        from telemffb.SettingsManager import SpringModeEnum
+        ac.spring_mode = SpringModeEnum.BASIC
+        ac.telemffb_controls_axes = True
+        ac.cyclic_spring_init = 1
+        ac.cpO_x = 0
+        ac.cpO_y = 0
+        ac.afcs_motion_rate = 4
+        self.mock_device._input_data.set_axis(x=0.0, y=0.0)
+        return ac
+
+    def _telem(self, **kw):
+        b = (TelemetryDataBuilder()
+             .ffb_type("joystick")
+             .on_ground(False)
+             .with_field("APServos", 0))
+        for k, v in kw.items():
+            b = b.with_field(k, v)
+        return b.build()
+
+    def test_trim_rate_drives_spring_center(self):
+        ac = self._inst()
+        # rate=0.5 * afcs_motion_rate=4 -> 2 device units per frame
+        ac.msfs_update_heli_controls(
+            self._telem(AW109_aileron_trim_rate=0.5,
+                        AW109_elevator_trim_rate=-0.25))
+        assert ac.afcsx_step_size == pytest.approx(2.0)
+        assert ac.afcsy_step_size == pytest.approx(-1.0)
+        assert ac.cpO_x == pytest.approx(2.0)
+        assert ac.cpO_y == pytest.approx(-1.0)
+
+    def test_spring_cpOffset_tracks_cpO_in_device_units(self):
+        # THE invariant guard: hardware must see the same device-unit offsets
+        # before and after the TASK002 normalization.
+        ac = self._inst()
+        ac.msfs_update_heli_controls(
+            self._telem(AW109_aileron_trim_rate=0.5,
+                        AW109_elevator_trim_rate=0.25))
+        assert ac.spring_x.cpOffset == round(ac.cpO_x)
+        assert ac.spring_y.cpOffset == round(ac.cpO_y)
+        assert ac.spring_x.cpOffset == 2
+        assert ac.spring_y.cpOffset == 1
+
+    def test_zero_trim_rate_holds_center(self):
+        ac = self._inst()
+        ac.msfs_update_heli_controls(
+            self._telem(AW109_aileron_trim_rate=0,
+                        AW109_elevator_trim_rate=0))
+        assert ac.cpO_x == 0 and ac.cpO_y == 0
+
+
+@pytest.mark.unit
+@pytest.mark.xplane
+@pytest.mark.helicopter
+class TestXAW109Collective(BaseTelemetryEffectTestCase):
+    """Collective spring: init handshake + AFCS ratio tracking."""
+
+    def _inst(self):
+        ac = self.create_aircraft_instance(
+            XAW109Helicopter, name="AW109",
+            _test_sim_is_xplane=True, _test_device_type="collective")
+        ac.telemffb_controls_axes = True
+        ac.collective_init = 0
+        ac.last_collective_y = None
+        return ac
+
+    def _telem(self, **kw):
+        b = (TelemetryDataBuilder()
+             .ffb_type("collective")
+             .on_ground(False)
+             .with_field("APServos", 0))
+        for k, v in kw.items():
+            b = b.with_field(k, v)
+        return b.build()
+
+    def test_ground_init_parks_at_full_down(self):
+        ac = self._inst()
+        self.mock_device._input_data.set_axis(x=0.0, y=1.0)  # full down
+        ac.msfs_update_collective(self._telem(SimOnGround=1))
+        assert ac.collective_init == 1
+        assert ac.cpO_y == 4096
+        # THE invariant guard: hardware sees full-down device units.
+        assert ac.spring_y.cpOffset == 4096
+
+    def test_air_init_uses_physical_position(self):
+        ac = self._inst()
+        self.mock_device._input_data.set_axis(x=0.0, y=0.5)
+        ac.msfs_update_collective(self._telem(SimOnGround=0))
+        assert ac.collective_init == 1
+        assert ac.cpO_y == round(0.5 * 4096)
+        assert ac.spring_y.cpOffset == round(0.5 * 4096)
+
+    def test_afcs_ratio_drives_spring_center(self):
+        ac = self._inst()
+        # init at full down (lever physically at 1.0 matches the init point)
+        self.mock_device._input_data.set_axis(x=0.0, y=1.0)
+        ac.msfs_update_collective(self._telem(SimOnGround=1))
+        assert ac.collective_init == 1
+        # AW109_collective_ratio 0.25 -> scale_clamp((0,1)->(4096,-4096)) = 2048
+        ac.msfs_update_collective(
+            self._telem(SimOnGround=0, AW109_collective_mode=1,
+                        AW109_collective_ratio=0.25))
+        assert ac.cpO_y == 2048
+        assert ac.spring_y.cpOffset == 2048
+
+    def test_afcs_ratio_full_up_reaches_negative_full_scale(self):
+        ac = self._inst()
+        self.mock_device._input_data.set_axis(x=0.0, y=1.0)
+        ac.msfs_update_collective(self._telem(SimOnGround=1))
+        ac.msfs_update_collective(
+            self._telem(SimOnGround=0, AW109_collective_mode=1,
+                        AW109_collective_ratio=1.0))
+        assert ac.cpO_y == -4096
+        assert ac.spring_y.cpOffset == -4096
+
+    def test_init_gate_blocks_until_centered(self):
+        ac = self._inst()
+        # lever far from the full-down init point -> init must not complete
+        self.mock_device._input_data.set_axis(x=0.0, y=-0.5)
+        ac.msfs_update_collective(self._telem(SimOnGround=1))
+        assert ac.collective_init == 0

--- a/tests/test_xaw109_pedals.py
+++ b/tests/test_xaw109_pedals.py
@@ -80,7 +80,7 @@ class TestXAW109PedalAfcs(BaseTelemetryEffectTestCase):
         t = self._telem(SimOnGround=0, AW109_rudder_trim_rate=-1,
                         AW109_rud_trim_zero=0.0, IAS=10.0)
         ac.msfs_update_pedals(t)
-        assert ac.cpO_x == before - ac.afcs_motion_rate
+        assert ac.cpO_x == before - ac.afcs_motion_rate / 4096
 
     def test_ias_fade_reduces_proportional_step(self):
         slow = self._inst()
@@ -111,7 +111,8 @@ class TestXAW109PedalAfcs(BaseTelemetryEffectTestCase):
         t = self._telem(SimOnGround=0,
                         AW109_ped_force_trim_release_pressed=1)
         ac.msfs_update_pedals(t)
-        assert ac.cpO_x == round(0.4 * 4096)
+        assert ac.cpO_x == pytest.approx(0.4)
+        assert ac.spring_x.cpOffset == round(0.4 * 4096)
 
 
 @pytest.mark.unit
@@ -149,14 +150,15 @@ class TestXAW109CyclicAfcs(BaseTelemetryEffectTestCase):
 
     def test_trim_rate_drives_spring_center(self):
         ac = self._inst()
-        # rate=0.5 * afcs_motion_rate=4 -> 2 device units per frame
+        # rate=0.5 * afcs_motion_rate=4 -> historical 2-device-unit step
+        # represented as 2/4096 internally.
         ac.msfs_update_heli_controls(
             self._telem(AW109_aileron_trim_rate=0.5,
                         AW109_elevator_trim_rate=-0.25))
-        assert ac.afcsx_step_size == pytest.approx(2.0)
-        assert ac.afcsy_step_size == pytest.approx(-1.0)
-        assert ac.cpO_x == pytest.approx(2.0)
-        assert ac.cpO_y == pytest.approx(-1.0)
+        assert ac.afcsx_step_size == pytest.approx(2 / 4096)
+        assert ac.afcsy_step_size == pytest.approx(-1 / 4096)
+        assert ac.cpO_x == pytest.approx(2 / 4096)
+        assert ac.cpO_y == pytest.approx(-1 / 4096)
 
     def test_spring_cpOffset_tracks_cpO_in_device_units(self):
         # THE invariant guard: hardware must see the same device-unit offsets
@@ -165,8 +167,8 @@ class TestXAW109CyclicAfcs(BaseTelemetryEffectTestCase):
         ac.msfs_update_heli_controls(
             self._telem(AW109_aileron_trim_rate=0.5,
                         AW109_elevator_trim_rate=0.25))
-        assert ac.spring_x.cpOffset == round(ac.cpO_x)
-        assert ac.spring_y.cpOffset == round(ac.cpO_y)
+        assert ac.spring_x.cpOffset == round(ac.cpO_x * 4096)
+        assert ac.spring_y.cpOffset == round(ac.cpO_y * 4096)
         assert ac.spring_x.cpOffset == 2
         assert ac.spring_y.cpOffset == 1
 
@@ -207,7 +209,7 @@ class TestXAW109Collective(BaseTelemetryEffectTestCase):
         self.mock_device._input_data.set_axis(x=0.0, y=1.0)  # full down
         ac.msfs_update_collective(self._telem(SimOnGround=1))
         assert ac.collective_init == 1
-        assert ac.cpO_y == 4096
+        assert ac.cpO_y == 1.0
         # THE invariant guard: hardware sees full-down device units.
         assert ac.spring_y.cpOffset == 4096
 
@@ -216,7 +218,7 @@ class TestXAW109Collective(BaseTelemetryEffectTestCase):
         self.mock_device._input_data.set_axis(x=0.0, y=0.5)
         ac.msfs_update_collective(self._telem(SimOnGround=0))
         assert ac.collective_init == 1
-        assert ac.cpO_y == round(0.5 * 4096)
+        assert ac.cpO_y == pytest.approx(0.5)
         assert ac.spring_y.cpOffset == round(0.5 * 4096)
 
     def test_afcs_ratio_drives_spring_center(self):
@@ -225,11 +227,11 @@ class TestXAW109Collective(BaseTelemetryEffectTestCase):
         self.mock_device._input_data.set_axis(x=0.0, y=1.0)
         ac.msfs_update_collective(self._telem(SimOnGround=1))
         assert ac.collective_init == 1
-        # AW109_collective_ratio 0.25 -> scale_clamp((0,1)->(4096,-4096)) = 2048
+        # AW109_collective_ratio 0.25 -> normalized center 0.5 -> 2048 on device.
         ac.msfs_update_collective(
             self._telem(SimOnGround=0, AW109_collective_mode=1,
                         AW109_collective_ratio=0.25))
-        assert ac.cpO_y == 2048
+        assert ac.cpO_y == pytest.approx(0.5)
         assert ac.spring_y.cpOffset == 2048
 
     def test_afcs_ratio_full_up_reaches_negative_full_scale(self):
@@ -239,7 +241,7 @@ class TestXAW109Collective(BaseTelemetryEffectTestCase):
         ac.msfs_update_collective(
             self._telem(SimOnGround=0, AW109_collective_mode=1,
                         AW109_collective_ratio=1.0))
-        assert ac.cpO_y == -4096
+        assert ac.cpO_y == -1.0
         assert ac.spring_y.cpOffset == -4096
 
     def test_init_gate_blocks_until_centered(self):


### PR DESCRIPTION
## Summary
- normalize remaining shared, DCS/BMS, and IL-2 spring-center intermediates
- retain device-unit conversion at the spring-condition boundary
- include all commits ahead of origin/refactor

## Validation
- .venv\\Scripts\\python.exe -m pytest tests -q -W ignore::ResourceWarning
- 1142 passed, 2 skipped